### PR TITLE
Avoid double // in ABSPATH (can cause issues on some *nix systems)

### DIFF
--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -63,8 +63,9 @@ if(isset($GLOBALS['wp_tests_options'])) {
 	}
 }
 
-// Load WordPress
-require_once ABSPATH . '/wp-settings.php';
+// Load WordPress: "untrailingslash" ABSPATH first of all to avoid double slashes in filepath,
+// while still working if ABSPATH did not include a trailing slash
+require_once rtrim( ABSPATH, '/\\' ) . '/wp-settings.php';
 
 // Delete any default posts & related data
 _delete_all_posts();


### PR DESCRIPTION
Hey man!

Noticed that `ABSPATH` is defined in `WPLoader::defineGlobals()` complete with trailing slash which is all good - but in `includes/bootstrap.php` we add an extra slash and - at least with a filesystem like mine - that won't work :-(

I was going to just remove the extra slash in the require_once statement so it follows the same pattern as the regular wp-config.php file, which also works here, but figured it wouldn't harm to make it tolerate an `ABSPATH` defined elsewhere without a slash, too.

