### PR TITLE
Fix WPBrowserMethods::seeMessage() & WPBrowserMethods::seeErrorMessage() for no class

### DIFF
--- a/src/WPBrowserMethods.php
+++ b/src/WPBrowserMethods.php
@@ -143,7 +143,9 @@
 			if ( is_array( $classes ) ) {
 				$classes = implode( '.', $classes );
 			}
-			$classes = '.' . $classes;
+			if ( $classes ) {
+				$classes = '.' . $classes;
+			}
 			$this->seeElement( '#message.error' . $classes );
 		}
 

--- a/src/WPBrowserMethods.php
+++ b/src/WPBrowserMethods.php
@@ -169,7 +169,9 @@
 			if ( is_array( $classes ) ) {
 				$classes = implode( '.', $classes );
 			}
-			$classes = '.' . $classes;
+			if ( $classes ) {
+				$classes = '.' . $classes;
+			}
 			$this->seeElement( '#message.updated' . $classes );
 		}
 


### PR DESCRIPTION
Currently, `WPBrowserMethods::seeMessage()` does not work if you do not pass it a class. It searches for `#message.updated.`, which is an invalid selector. This pull request makes it so that the `.` only gets added if `$classes` is non-empty.