### PR TITLE
Add codecept_relative_path() to bootstrap

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -33,3 +33,8 @@ function codecept_data_dir($appendPath = '')
 {
     return \Codeception\Configuration::dataDir() . $appendPath;
 }
+
+function codecept_relative_path($path)
+{
+    return substr($path, strlen(codecept_root_dir()));
+}


### PR DESCRIPTION
Fixes fatal error: `Call to undefined function Codeception\Subscriber\codecept_relative_path() `

I was having a similar issue to https://github.com/lucatume/wp-browser/issues/18 for some of my tests after upgrading Codeception. It seems a new function was introduced into https://github.com/Codeception/Codeception/blob/2.1/autoload.php which is missing in the wp-browser version. This seems to fix it and allows the tests to run.