### PR TITLE
Support Codeception's @env annotations by extending Codeception's Test

### DIFF
--- a/src/includes/testcase.php
+++ b/src/includes/testcase.php
@@ -3,7 +3,7 @@
 require_once dirname( __FILE__ ) . '/factory.php';
 require_once dirname( __FILE__ ) . '/trac.php';
 
-class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
+class WP_UnitTestCase extends \Codeception\TestCase\Test {
 
 	protected static $forced_tickets = array();
 	protected $expected_deprecated = array();


### PR DESCRIPTION
Codeception supports the exclusion/inclusion of tests using the `@env` annotation within test docblocks. A prerequisite to this feature being supported is that the Test must be an `instanceof \Codeception\TestCase\Test`.

The `WP_UnitTestCase` extends `PHPUnit_Framework_TestCase`. So does `\Codeception\TestCase\Test` (via `\Codeception\TestCase`).

This changeset extends the Codeception Test class.