### PR TITLE
Bad _last_response value for multiple consecutive _handleAjax

### DIFF
--- a/src/Codeception/TestCase/WPAjaxTestCase.php
+++ b/src/Codeception/TestCase/WPAjaxTestCase.php
@@ -162,18 +162,6 @@ abstract class WPAjaxTestCase extends WPTestCase{
 	}
 
 	/**
-	 * Switch between user roles
-	 * E.g. administrator, editor, author, contributor, subscriber
-	 * @param string $role
-	 */
-	protected function _setRole( $role ) {
-		$post = $_POST;
-		$user_id = self::factory()->user->create( array( 'role' => $role ) );
-		wp_set_current_user( $user_id );
-		$_POST = array_merge($_POST, $post);
-	}
-
-	/**
 	 * Mimic the ajax handling of admin-ajax.php
 	 * Capture the output via output buffering, and if there is any, store
 	 * it in $this->_last_message.

--- a/src/Codeception/TestCase/WPAjaxTestCase.php
+++ b/src/Codeception/TestCase/WPAjaxTestCase.php
@@ -180,6 +180,7 @@ abstract class WPAjaxTestCase extends WPTestCase{
 	 * @param string $action
 	 */
 	protected function _handleAjax($action) {
+		$this->_last_response = NULL;
 
 		// Start output buffering
 		ini_set( 'implicit_flush', false );

--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -91,6 +91,18 @@ class WPTestCase extends \Codeception\TestCase\Test {
 		}
 	}
 
+	/**
+	 * Switch between user roles
+	 * E.g. administrator, editor, author, contributor, subscriber
+	 * @param string $role
+	 */
+	protected function _setRole( $role ) {
+		$post = $_POST;
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+		$_POST = array_merge($_POST, $post);
+	}
+
 	function __isset($name)
 	{
 		return 'factory' === $name;


### PR DESCRIPTION
All Ajax call responses are appended in the response if you have more than one _handleAjax call in a single test