### PR TITLE
Added parent method call in _before() hook

### DIFF
--- a/src/Codeception/Module/WordPress.php
+++ b/src/Codeception/Module/WordPress.php
@@ -167,6 +167,7 @@ EOF;
 
     public function _failed(TestInterface $test, $fail)
     {
+        parent::_failed($test, $fail);
     }
 
     public function _after(TestInterface $test)

--- a/src/Codeception/Module/WordPress.php
+++ b/src/Codeception/Module/WordPress.php
@@ -326,11 +326,4 @@ EOF;
         $uri = str_replace($this->siteUrl, 'http://localhost', str_replace(urlencode($this->siteUrl), urlencode('http://localhost'), $uri));
         return parent::getAbsoluteUrlFor($uri);
     }
-
-    public function getInternalDomains()
-    {
-        $internalDomains = [];
-        $internalDomains[] = '/^' . preg_quote(parse_url($this->siteUrl, PHP_URL_HOST)) . '$/';
-        return $internalDomains;
-    }
 }

--- a/src/Codeception/Module/WordPress.php
+++ b/src/Codeception/Module/WordPress.php
@@ -326,4 +326,11 @@ EOF;
         $uri = str_replace($this->siteUrl, 'http://localhost', str_replace(urlencode($this->siteUrl), urlencode('http://localhost'), $uri));
         return parent::getAbsoluteUrlFor($uri);
     }
+
+    public function getInternalDomains()
+    {
+        $internalDomains = [];
+        $internalDomains[] = '/^' . preg_quote(parse_url($this->siteUrl, PHP_URL_HOST)) . '$/';
+        return $internalDomains;
+    }
 }

--- a/src/tad/WPBrowser/Connector/WordPress.php
+++ b/src/tad/WPBrowser/Connector/WordPress.php
@@ -63,7 +63,13 @@ class WordPress extends Universal
         $requestServer = $request->getServer();
         $requestFiles = $this->remapFiles($request->getFiles());
 
-        $uri = str_replace('http://localhost', '', $request->getUri());
+        // $uri = str_replace('http://localhost', '', $request->getUri());
+        $parseResult = parse_url($request->getUri());
+        $uri = $parseResult["path"];
+        if (array_key_exists("query", $parseResult)) {
+            $uri .= "?".$parseResult["query"];
+            
+        }
 
         $requestRequestArray = $this->remapRequestParameters($request->getParameters());
 

--- a/src/tad/WPBrowser/Connector/WordPress.php
+++ b/src/tad/WPBrowser/Connector/WordPress.php
@@ -63,13 +63,7 @@ class WordPress extends Universal
         $requestServer = $request->getServer();
         $requestFiles = $this->remapFiles($request->getFiles());
 
-        // $uri = str_replace('http://localhost', '', $request->getUri());
-        $parseResult = parse_url($request->getUri());
-        $uri = $parseResult["path"];
-        if (array_key_exists("query", $parseResult)) {
-            $uri .= "?".$parseResult["query"];
-            
-        }
+        $uri = str_replace('http://localhost', '', $request->getUri());
 
         $requestRequestArray = $this->remapRequestParameters($request->getParameters());
 


### PR DESCRIPTION
Without the call, the dumps of requests causing failures are not saved to _output directory.

I believe other hooks also need to be reviewed in terms of the need to call parent method.