### PR TITLE
added following override methods in WPBrowser

### DIFF
--- a/src/Codeception/Module/WPBrowser.php
+++ b/src/Codeception/Module/WPBrowser.php
@@ -95,4 +95,20 @@ class WPBrowser extends PhpBrowser
 
         parent::validateConfig();
     }
+
+    public function activatePlugin($pluginSlug)
+    {
+        $this->checkOption('//*[@data-slug="' . $pluginSlug . '"]/th/input');
+        $this->selectOption('action', 'activate-selected');
+        $this->click("doaction");
+    }
+
+    public function deactivatePlugin($pluginSlug)
+    {
+        $this->checkOption('//*[@data-slug="' . $pluginSlug . '"]/th/input');
+        $this->selectOption('action', 'deactivate-selected');
+        $this->click("doaction");
+    }
+
+
 }


### PR DESCRIPTION
"activatePlugin" and "deactivatePlugin" are failure when I use PHPBrowser.
WordPress's version is ver 4.5.3.

Message from wpcept is ...
```
 Step  Activate plugin "some/plugin"
 Fail  Link or Button by name or CSS or XPath element with 'table.plugins tr[data-slug='some/plugin'] span.activate > a:first-of-type' was not found.
```

I added following override methods in WPBrowser.
- activatePlugin
- deactivatePlugin