### PR TITLE
Make importSqlDumpFile public so it can be called by actions

### DIFF
--- a/src/Codeception/Module/WPDb.php
+++ b/src/Codeception/Module/WPDb.php
@@ -244,7 +244,10 @@ class WPDb extends ExtendedDb
 		}
 	}
 
-	private function importSqlDumpFile()
+	/**
+	 * Import the SQL dump file if populate is enabled.
+	 */
+	public function importSqlDumpFile()
 	{
 		if ($this->config['populate']) {
 			$this->cleanup();


### PR DESCRIPTION
Allows `$I->importSqlDumpFile();` during `_before()` calls.