### PR TITLE
Use prefixed users table name instead of default users table name

### DIFF
--- a/src/Codeception/Module/WPDb.php
+++ b/src/Codeception/Module/WPDb.php
@@ -1009,7 +1009,7 @@ class WPDb extends ExtendedDb
 	 */
 	public function grabUserIdFromDatabase($userLogin)
 	{
-		return $this->grabFromDatabase('wp_users', 'ID', ['user_login' => $userLogin]);
+		return $this->grabFromDatabase($this->getUsersTableName(), 'ID', ['user_login' => $userLogin]);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I send this PR because I encountered a little trouble when I use `WPDb::grabUserIdFromDatabase` in my acceptance test case. This is sample code below:

```php
class FooCest {
    public function testUserExists(\AcceptanceTester $I) {
        $I->assertGreaterThan(0, $I->grabUserIdFromDatabase('foo'));
    }
}
```

When I run the test, I got an error message:

```shell
[PDOException] SQLSTATE[42S02]: Base table or view not found: 1146 Table 'dummy_db.wp_users' doesn't exist
```

I try to change the table name in `WPDb::grabUserIdFromDatabase` from `wp_users` to `$this->getUsersTableName()`, and the test case passed.