### PR TITLE
Fix PHPUnit shims to integrate with Codeception ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
   email: false
 
 php:
+  - '5.6'
   - '7.0'
   - '7.1'
   - '7.2'
@@ -76,7 +77,11 @@ before_install:
   - export PATH=vendor/bin:$PATH
 
 install:
-  - composer install --prefer-dist
+  # export a var storing the `codecept run` command options
+  - export CC_OPTIONS=''
+  # if the PHP version is 5.6 then use the modified composer configuration file and skip PHP 7 tests
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.6" ]]; then mv build/php-56-composer.json composer.json && export CC_OPTIONS="$CC_OPTIONS --skip-group php7"; fi
+  - composer update
   # install WordPress in the `wordpress` folder
   - cd $WP_FOLDER
   - wp core download --version=$WP_VERSION
@@ -102,20 +107,18 @@ before_script:
   # restart Nnginx and PHP-FPM services
   - sudo service php5-fpm restart
   - sudo service nginx restart
-
   # build Codeception modules
   - codecept build
-
    # set the correct path to phantomjs bin
   - sed -i "s_%%phantomjs%%_$(which phantomjs)_" $TRAVIS_BUILD_DIR/.env
 
 script:
-  - codecept run unit
-  - codecept run acceptance
-  - codecept run phantomjs
-  - codecept run functional
-  - codecept run climodule
-  - codecept run wpmodule
-  - codecept run wploadersuite
-  - codecept run muloader
-  - codecept run cli
+  - codecept run unit $CC_OPTIONS
+  - codecept run acceptance $CC_OPTIONS
+  - codecept run phantomjs $CC_OPTIONS
+  - codecept run functional $CC_OPTIONS
+  - codecept run climodule $CC_OPTIONS
+  - codecept run wpmodule $CC_OPTIONS
+  - codecept run wploadersuite $CC_OPTIONS
+  - codecept run muloader $CC_OPTIONS
+  - codecept run cli $CC_OPTIONS

--- a/build/php-56-composer.json
+++ b/build/php-56-composer.json
@@ -1,0 +1,50 @@
+{
+  "name": "lucatume/wp-browser",
+  "type": "library",
+  "description": "WordPress extension of the PhpBrowser class.",
+  "keywords": [
+    "wordpress",
+    "codeception"
+  ],
+  "homepage": "http://github.com/lucatume/wp-browser",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "theAverageDev (Luca Tumedei)",
+      "email": "luca@theaveragedev.com",
+      "homepage": "http://theaveragedev.com",
+      "role": "Developer"
+    }
+  ],
+  "prefer-stable": true,
+  "require": {
+    "lucatume/wp-browser-commons": "^1.2.5",
+    "lucatume/codeception-setup-local": "~1.0",
+    "wp-cli/wp-cli": "^1.1",
+    "symfony/process": ">=2.7 <5.0",
+    "antecedent/patchwork": "^2.0",
+    "codeception/codeception": "^2.3",
+    "gumlet/php-image-resize": "^1.6",
+    "electrolinux/phpquery": "^0.9.6",
+    "phpunit/phpunit": "<7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Codeception\\": "src\\Codeception",
+      "tad\\": "src\\tad"
+    },
+    "files": [
+      "src/tad/WPBrowser/functions.php",
+      "shims.php"
+    ]
+  },
+  "require-dev": {
+    "mikey179/vfsStream": "^1.6",
+    "ofbeaton/console-tester": "^1.1",
+    "site5/phantoman": "^1.1",
+    "vlucas/phpdotenv": "^2.4"
+  },
+  "bin": [
+    "wpcept"
+  ]
+}

--- a/shims.php
+++ b/shims.php
@@ -4,8 +4,33 @@ namespace {
 
 	// PHPUnit 6 compat
 	if (class_exists('PHPUnit\Framework\TestCase')) {
-		if ( ! class_exists('PHPUnit_Util_Getopt') && class_exists('PHPUnit\Util\Getopt')) {
-			class_alias('PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt');
+		$aliases = [
+			//			'PHPUnit\Framework\Test'                       => 'PHPUnit_Framework_Test',
+			//			'PHPUnit\Framework\TestSuite'                  => 'PHPUnit_Framework_TestSuite',
+			//			'PHPUnit\Framework\TestCase'                   => 'PHPUnit_Framework_TestCase',
+			'PHPUnit\Framework\Assert' => 'PHPUnit_Framework_Assert',
+			//			'PHPUnit\Framework\Exception'                  => 'PHPUnit_Framework_Exception',
+			//			'PHPUnit\Framework\ExpectationFailedException' => 'PHPUnit_Framework_ExpectationFailedException',
+			//			'PHPUnit\Framework\Warning'                    => 'PHPUnit_Framework_Warning',
+			//			'PHPUnit\Framework\Error\Notice'               => 'PHPUnit_Framework_Error_Notice',
+			//			'PHPUnit\Framework\Error\Warning'              => 'PHPUnit_Framework_Error_Warning',
+			//			'PHPUnit\Framework\TestListener'               => 'PHPUnit_Framework_TestListener',
+			//			'PHPUnit\Framework\AssertionFailedError'       => 'PHPUnit_Framework_AssertionFailedError',
+			'PHPUnit\Util\Getopt'      => 'PHPUnit_Util_Getopt',
+			//			'PHPUnit\Util\GlobalState'                     => 'PHPUnit_Util_GlobalState',
+		];
+
+		foreach ($aliases as $new => $old) {
+			if (!class_exists($old) && class_exists($new)) {
+				class_alias($new, $old);
+			}
+			// PHPUnit 6 compat
+			if (class_exists('PHPUnit\Framework\TestCase')) {
+				if (!class_exists('PHPUnit_Util_Getopt') && class_exists('PHPUnit\Util\Getopt')) {
+					class_alias('PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt');
+				}
+			}
 		}
 	}
 }
+

--- a/shims.php
+++ b/shims.php
@@ -2,28 +2,10 @@
 
 namespace {
 
-    // PHPUnit 6 compat
-    if (class_exists('PHPUnit\Framework\TestCase')) {
-		$aliases = [
-			'PHPUnit\Framework\Test'                       => 'PHPUnit_Framework_Test',
-			'PHPUnit\Framework\TestSuite'                  => 'PHPUnit_Framework_TestSuite',
-			'PHPUnit\Framework\TestCase'                   => 'PHPUnit_Framework_TestCase',
-			'PHPUnit\Framework\Assert'                     => 'PHPUnit_Framework_Assert',
-			'PHPUnit\Framework\Exception'                  => 'PHPUnit_Framework_Exception',
-			'PHPUnit\Framework\ExpectationFailedException' => 'PHPUnit_Framework_ExpectationFailedException',
-			'PHPUnit\Framework\Warning'                    => 'PHPUnit_Framework_Warning',
-			'PHPUnit\Framework\Error\Notice'               => 'PHPUnit_Framework_Error_Notice',
-			'PHPUnit\Framework\Error\Warning'              => 'PHPUnit_Framework_Error_Warning',
-			'PHPUnit\Framework\TestListener'               => 'PHPUnit_Framework_TestListener',
-			'PHPUnit\Framework\AssertionFailedError'       => 'PHPUnit_Framework_AssertionFailedError',
-			'PHPUnit\Util\Getopt'                          => 'PHPUnit_Util_Getopt',
-			'PHPUnit\Util\GlobalState'                     => 'PHPUnit_Util_GlobalState',
-		];
-
-		foreach ($aliases as $new => $old) {
-			if (!class_exists($old) && class_exists($new)) {
-				class_alias($new, $old);
-			}
+	// PHPUnit 6 compat
+	if (class_exists('PHPUnit\Framework\TestCase')) {
+		if ( ! class_exists('PHPUnit_Util_Getopt') && class_exists('PHPUnit\Util\Getopt')) {
+			class_alias('PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt');
 		}
-    }
+	}
 }

--- a/shims.php
+++ b/shims.php
@@ -15,18 +15,4 @@ namespace {
 			}
 		}
 	}
-
-	$testcaseAliases = [
-		'Codeception\TestCase\WpTestCase' => 'WP_UnitTestCase',
-		'Codeception\TestCase\WPRestApiTestCase' => 'WP_Test_REST_TestCase',
-		'Codeception\TestCase\WPXMLRPCTestCase' => 'WP_XMLRPC_UnitTestCase',
-		'Codeception\TestCase\WPAjaxTestCase' => 'WP_Ajax_UnitTestCase',
-		'Codeception\TestCase\WPCanonicalTestCase' => 'WP_Canonical_UnitTestCase',
-		'Codeception\TestCase\WPRestControllerTestCase' => 'WP_Test_REST_Controller_Testcase',
-		'Codeception\TestCase\WPRestPostTypeControllerTestCase' => 'WP_Test_REST_Post_Type_Controller_Testcase',
-	];
-
-	foreach ($testcaseAliases as $old => $new) {
-		class_alias($new, $old, false);
-	}
 }

--- a/shims.php
+++ b/shims.php
@@ -2,20 +2,11 @@
 
 namespace {
 
+	// PHPUnit 6+ compat
 	if (class_exists('PHPUnit\Framework\TestCase')) {
 		$aliases = [
-			// PHPUnit 6+ compat
 			'PHPUnit\Framework\Assert' => 'PHPUnit_Framework_Assert',
 			'PHPUnit\Util\Getopt' => 'PHPUnit_Util_Getopt',
-
-			// Core test case classes
-			'Codeception\TestCase\WpTestCase' => 'WP_UnitTestCase',
-			'Codeception\TestCase\WPRestApiTestCase' => 'WP_Test_REST_TestCase',
-			'Codeception\TestCase\WPXMLRPCTestCase' => 'WP_XMLRPC_UnitTestCase',
-			'Codeception\TestCase\WPAjaxTestCase' => 'WP_Ajax_UnitTestCase',
-			'Codeception\TestCase\WPCanonicalTestCase' => 'WP_Canonical_UnitTestCase',
-			'Codeception\TestCase\WPRestControllerTestCase' => 'WP_Test_REST_Controller_Testcase',
-			'Codeception\TestCase\WPRestPostTypeControllerTestCase' => 'WP_Test_REST_Post_Type_Controller_Testcase',
 		];
 
 		foreach ($aliases as $new => $old) {
@@ -23,5 +14,19 @@ namespace {
 				class_alias($new, $old);
 			}
 		}
+	}
+
+	$testcaseAliases = [
+		'Codeception\TestCase\WpTestCase' => 'WP_UnitTestCase',
+		'Codeception\TestCase\WPRestApiTestCase' => 'WP_Test_REST_TestCase',
+		'Codeception\TestCase\WPXMLRPCTestCase' => 'WP_XMLRPC_UnitTestCase',
+		'Codeception\TestCase\WPAjaxTestCase' => 'WP_Ajax_UnitTestCase',
+		'Codeception\TestCase\WPCanonicalTestCase' => 'WP_Canonical_UnitTestCase',
+		'Codeception\TestCase\WPRestControllerTestCase' => 'WP_Test_REST_Controller_Testcase',
+		'Codeception\TestCase\WPRestPostTypeControllerTestCase' => 'WP_Test_REST_Post_Type_Controller_Testcase',
+	];
+
+	foreach ($testcaseAliases as $old => $new) {
+		class_alias($new, $old);
 	}
 }

--- a/shims.php
+++ b/shims.php
@@ -11,6 +11,7 @@ namespace {
 			// inverse aliases
 			'PHPUnit_Runner_Version' => 'PHPUnit\Runner\Version',
 			'PHPUnit_Framework_TestResult' => 'PHPUnit\Framework\TestResult',
+			'PHPUnit_Framework_Test' => 'PHPUnit\Framework\Test',
 		];
 
 		foreach ($aliases as $new => $old) {

--- a/shims.php
+++ b/shims.php
@@ -10,6 +10,7 @@ namespace {
 
 			// inverse aliases
 			'PHPUnit_Runner_Version' => 'PHPUnit\Runner\Version',
+			'PHPUnit_Framework_TestResult' => 'PHPUnit\Framework\TestResult',
 		];
 
 		foreach ($aliases as $new => $old) {

--- a/shims.php
+++ b/shims.php
@@ -2,35 +2,26 @@
 
 namespace {
 
-	// PHPUnit 6 compat
 	if (class_exists('PHPUnit\Framework\TestCase')) {
 		$aliases = [
-			//			'PHPUnit\Framework\Test'                       => 'PHPUnit_Framework_Test',
-			//			'PHPUnit\Framework\TestSuite'                  => 'PHPUnit_Framework_TestSuite',
-			//			'PHPUnit\Framework\TestCase'                   => 'PHPUnit_Framework_TestCase',
+			// PHPUnit 6+ compat
 			'PHPUnit\Framework\Assert' => 'PHPUnit_Framework_Assert',
-			//			'PHPUnit\Framework\Exception'                  => 'PHPUnit_Framework_Exception',
-			//			'PHPUnit\Framework\ExpectationFailedException' => 'PHPUnit_Framework_ExpectationFailedException',
-			//			'PHPUnit\Framework\Warning'                    => 'PHPUnit_Framework_Warning',
-			//			'PHPUnit\Framework\Error\Notice'               => 'PHPUnit_Framework_Error_Notice',
-			//			'PHPUnit\Framework\Error\Warning'              => 'PHPUnit_Framework_Error_Warning',
-			//			'PHPUnit\Framework\TestListener'               => 'PHPUnit_Framework_TestListener',
-			//			'PHPUnit\Framework\AssertionFailedError'       => 'PHPUnit_Framework_AssertionFailedError',
-			'PHPUnit\Util\Getopt'      => 'PHPUnit_Util_Getopt',
-			//			'PHPUnit\Util\GlobalState'                     => 'PHPUnit_Util_GlobalState',
+			'PHPUnit\Util\Getopt' => 'PHPUnit_Util_Getopt',
+
+			// Core test case classes
+			'Codeception\TestCase\WpTestCase' => 'WP_UnitTestCase',
+			'Codeception\TestCase\WPRestApiTestCase' => 'WP_Test_REST_TestCase',
+			'Codeception\TestCase\WPXMLRPCTestCase' => 'WP_XMLRPC_UnitTestCase',
+			'Codeception\TestCase\WPAjaxTestCase' => 'WP_Ajax_UnitTestCase',
+			'Codeception\TestCase\WPCanonicalTestCase' => 'WP_Canonical_UnitTestCase',
+			'Codeception\TestCase\WPRestControllerTestCase' => 'WP_Test_REST_Controller_Testcase',
+			'Codeception\TestCase\WPRestPostTypeControllerTestCase' => 'WP_Test_REST_Post_Type_Controller_Testcase',
 		];
 
 		foreach ($aliases as $new => $old) {
 			if (!class_exists($old) && class_exists($new)) {
 				class_alias($new, $old);
 			}
-			// PHPUnit 6 compat
-			if (class_exists('PHPUnit\Framework\TestCase')) {
-				if (!class_exists('PHPUnit_Util_Getopt') && class_exists('PHPUnit\Util\Getopt')) {
-					class_alias('PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt');
-				}
-			}
 		}
 	}
 }
-

--- a/shims.php
+++ b/shims.php
@@ -11,7 +11,7 @@ namespace {
 
 		foreach ($aliases as $new => $old) {
 			if (!class_exists($old) && class_exists($new)) {
-				class_alias($new, $old);
+				class_alias($new, $old, false);
 			}
 		}
 	}
@@ -27,6 +27,6 @@ namespace {
 	];
 
 	foreach ($testcaseAliases as $old => $new) {
-		class_alias($new, $old);
+		class_alias($new, $old, false);
 	}
 }

--- a/shims.php
+++ b/shims.php
@@ -7,6 +7,9 @@ namespace {
 		$aliases = [
 			'PHPUnit\Framework\Assert' => 'PHPUnit_Framework_Assert',
 			'PHPUnit\Util\Getopt' => 'PHPUnit_Util_Getopt',
+
+			// inverse aliases
+			'PHPUnit_Runner_Version' => 'PHPUnit\Runner\Version',
 		];
 
 		foreach ($aliases as $new => $old) {

--- a/src/Codeception/TestCase/WPAjaxTestCase.php
+++ b/src/Codeception/TestCase/WPAjaxTestCase.php
@@ -3,14 +3,6 @@
 namespace Codeception\TestCase;
 
 /**
- * Ajax test cases
- *
- * @package    WordPress
- * @subpackage UnitTests
- * @since      3.4.0
- */
-
-/**
  * Ajax test case class
  *
  * @package    WordPress

--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -162,7 +162,7 @@ require_once rtrim(ABSPATH, '/\\') . '/wp-settings.php';
 // Delete any default posts & related data
 _without_filters('_delete_all_posts');
 
-require dirname(__FILE__) . '/testcase.php';
+// Do not load these files as mirrored by the WPTestCase et al.
 require dirname(__FILE__) . '/testcase-rest-api.php';
 require dirname(__FILE__) . '/testcase-xmlrpc.php';
 require dirname(__FILE__) . '/testcase-ajax.php';

--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -162,13 +162,6 @@ require_once rtrim(ABSPATH, '/\\') . '/wp-settings.php';
 // Delete any default posts & related data
 _without_filters('_delete_all_posts');
 
-// Do not load these files as mirrored by the WPTestCase et al.
-require dirname(__FILE__) . '/testcase-rest-api.php';
-require dirname(__FILE__) . '/testcase-xmlrpc.php';
-require dirname(__FILE__) . '/testcase-ajax.php';
-require dirname(__FILE__) . '/testcase-canonical.php';
-require dirname(__FILE__) . '/exceptions.php';
-require dirname(__FILE__) . '/utils.php';
 // let's make sure we are using a version of WordPress that integrates the WP_REST_Server class
 if (class_exists('WP_REST_Server')) {
 	require dirname(__FILE__) . '/spy-rest-server.php';

--- a/tests/unit/tad/WPBrowser/Snapshot/WPHtmlOutputDriverTest.php
+++ b/tests/unit/tad/WPBrowser/Snapshot/WPHtmlOutputDriverTest.php
@@ -4,6 +4,9 @@ namespace tad\WPBrowser\Snapshot;
 
 use tad\WPBrowser\Snapshot\WPHtmlOutputDriver as Driver;
 
+/**
+ * @group php7
+ */
 class WPHtmlOutputDriverTest extends \Codeception\Test\Unit {
 
 	public $currentUrl = 'http://example.com';


### PR DESCRIPTION
This PR restores wp-browser shims to their simpler nature since Codecdeption handles PHPUnit shims already.