### PR TITLE
Look for WPHtmlOutputDriver in the correct place

### DIFF
--- a/src/tad/WPBrowser/Snapshot/WPHtmlOutputDriver.php
+++ b/src/tad/WPBrowser/Snapshot/WPHtmlOutputDriver.php
@@ -22,4 +22,4 @@ namespace tad\WPBrowser\Snapshot;
  * @see     https://github.com/spatie/wp-snapshot-assertions
  * @see     https://packagist.org/packages/lucatume/wp-snapshot-assertions
  */
-class WPHtmlOutputDriver extends tad\WP\Snapshots\WPHtmlOutputDriver {}
+class WPHtmlOutputDriver extends \tad\WP\Snapshots\WPHtmlOutputDriver {}

--- a/src/tad/WPBrowser/Snapshot/WPHtmlOutputDriver.php
+++ b/src/tad/WPBrowser/Snapshot/WPHtmlOutputDriver.php
@@ -19,7 +19,7 @@ namespace tad\WPBrowser\Snapshot;
  *
  * @see     https://github.com/spatie/phpunit-snapshot-assertions
  * @see     https://packagist.org/packages/spatie/phpunit-snapshot-assertions
- * @see     https://github.com/spatie/wp-snapshot-assertions
+ * @see     https://github.com/lucatume/wp-snapshot-assertions
  * @see     https://packagist.org/packages/lucatume/wp-snapshot-assertions
  */
 class WPHtmlOutputDriver extends \tad\WP\Snapshots\WPHtmlOutputDriver {}


### PR DESCRIPTION
When moved to use as an alias it was looking for the incorrect class `tad\WPBrowser\Snapshot\tad\WP\Snapshots\WPHtmlOutputDriver`.