### PR TITLE
Set an upper Codeception version bound of 2.4.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [2.1.6] 2018-09-25;
+### Fixed
+- set an upper version bound for Codeception of `2.4.5` to avoid incompatibility issues between `WPDb` and `Db` modules
+
 ## [2.1.5] 2018-08-01;
 ### Fixed
 - add the `waitlock` parameter to the `WPDb` template configuration

--- a/changelog.md
+++ b/changelog.md
@@ -796,6 +796,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Reference to ModuleConfigException class in WPLoader class.
 
 [unreleased]: https://github.com/lucatume/wp-browser/compare/2.1.5...HEAD
+[2.1.6]: https://github.com/lucatume/wp-browser/compare/2.1.5...2.1.6
 [2.1.5]: https://github.com/lucatume/wp-browser/compare/2.1.4...2.1.5
 [2.1.4]: https://github.com/lucatume/wp-browser/compare/2.1.3...2.1.4
 [2.1.3]: https://github.com/lucatume/wp-browser/compare/2.1.2...2.1.3

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "wp-cli/wp-cli": "^1.1",
     "symfony/process": ">=2.7 <5.0",
     "antecedent/patchwork": "^2.0",
-    "codeception/codeception": "^2.3",
+    "codeception/codeception": ">=2.3 <=2.4.5",
     "gumlet/php-image-resize": "^1.6",
     "lucatume/wp-snaphot-assertions": "~1.0",
     "vlucas/phpdotenv": "^2.4"


### PR DESCRIPTION
The current code of the WPDb module is not compatible with the modification made to the Db module in Codeception `2.4.5`.  
As I work on a fix this should prevent installations from updating Codeception to a version that is not compatible with the current version of wp-browser.