### PR TITLE
Set an upper bound for Codeception of 2.4.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [1.24.6] 2018-09-25;
+### Fixed
+- set an upper version bound for Codeception of `2.4.5` to avoid incompatibility issues between `WPDb` and `Db` modules
+
 ## [1.24.5] 2018-08-01;
 ### Fixed
 - add the `waitlock` parameter to the `WPDb` template configuration
@@ -783,7 +787,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Reference to ModuleConfigException class in WPLoader class.
 
-[unreleased]: https://github.com/lucatume/wp-browser/compare/1.24.5...HEAD
+[unreleased]: https://github.com/lucatume/wp-browser/compare/1.24.6...HEAD
+[1.24.6]: https://github.com/lucatume/wp-browser/compare/1.24.5...1.24.6
 [1.24.5]: https://github.com/lucatume/wp-browser/compare/1.24.4...1.24.5
 [1.24.4]: https://github.com/lucatume/wp-browser/compare/1.24.3...1.24.4
 [1.24.3]: https://github.com/lucatume/wp-browser/compare/1.24.2...1.24.3

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "wp-cli/wp-cli": "^1.1",
     "symfony/process": ">=2.7 <5.0",
     "antecedent/patchwork": "^2.0",
-    "codeception/codeception": "^2.3",
+    "codeception/codeception": ">=2.3 <=2.4.5",
     "gumlet/php-image-resize": "^1.6",
     "vlucas/phpdotenv": "^2.4"
   },


### PR DESCRIPTION
PHP 5.6 compat version of https://github.com/lucatume/wp-browser/pull/180.  
The current code of the WPDb module is not compatible with the modification made to the Db module in Codeception 2.4.5.
As I work on a fix this should prevent installations from updating Codeception to a version that is not compatible with the current version of wp-browser.