### PR TITLE
Normalize string new line bytecodes in WPFileSystemTest

### DIFF
--- a/src/Codeception/Module/WPFilesystem.php
+++ b/src/Codeception/Module/WPFilesystem.php
@@ -1047,7 +1047,7 @@ PHP;
 /*
 Theme Name: $name
 Author: wp-browser
-Description: $name 
+Description: $name
 Version: 1.0
 */
 CSS;

--- a/tests/_support/functions.php
+++ b/tests/_support/functions.php
@@ -45,7 +45,5 @@ function getMySQLVersion()
 */
 function normalizeNewLine(string $str)
 {
-	$str = str_replace("\r\n", "\n", $str);
-	$str = str_replace("\r", "\n", $str);
-	return $str;
+	return preg_replace('~(*BSR_ANYCRLF)\R~', "\r\n", $str);
 }

--- a/tests/_support/functions.php
+++ b/tests/_support/functions.php
@@ -36,3 +36,14 @@ function getMySQLVersion()
 	preg_match('@[0-9]+\.[0-9]+\.[0-9]+@', $output, $version);
 	return $version[0];
 }
+
+/**
+* Normalizes a string new line bytecode for file comparison asserts
+* through Unix and Windows environments.
+*
+* @see https://stackoverflow.com/a/7836692/2056484
+*/
+function normalizeNewLine(string $str)
+{
+	return preg_replace('~(*BSR_ANYCRLF)\R~', "\r\n", $str);
+}

--- a/tests/_support/functions.php
+++ b/tests/_support/functions.php
@@ -45,5 +45,7 @@ function getMySQLVersion()
 */
 function normalizeNewLine(string $str)
 {
-	return preg_replace('~\R~u', "\r\n", $str);
+	$str = str_replace("\r\n", "\n", $str);
+	$str = str_replace("\r", "\n", $str);
+	return $str;
 }

--- a/tests/_support/functions.php
+++ b/tests/_support/functions.php
@@ -38,12 +38,12 @@ function getMySQLVersion()
 }
 
 /**
-* Normalizes a string new line bytecode for file comparison asserts
+* Normalizes a string new line bytecode for comparison
 * through Unix and Windows environments.
 *
 * @see https://stackoverflow.com/a/7836692/2056484
 */
 function normalizeNewLine(string $str)
 {
-	return preg_replace('~(*BSR_ANYCRLF)\R~', "\r\n", $str);
+	return preg_replace('~\R~u', "\r\n", $str);
 }

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -8,6 +8,7 @@ use Codeception\Lib\ModuleContainer;
 use Codeception\TestInterface;
 use PHPUnit\Framework\AssertionFailedError;
 use tad\WPBrowser\Filesystem\Utils;
+use function tad\WPBrowser\Tests\Support\normalizeNewLine;
 
 class WPFilesystemTest extends \Codeception\Test\Unit {
 
@@ -754,7 +755,7 @@ Description: foo
 
 echo 'Hello world';
 PHP;
-        $this->assertStringEqualsFile($pluginFile, $expected);
+        $this->assertStringEqualsFile(normalizeNewLine($pluginFile), normalizeNewLine($expected));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -788,7 +789,7 @@ Description: Test mu-plugin 1
 
 echo 'Hello world';
 PHP;
-        $this->assertStringEqualsFile($muPluginFile, $expected);
+        $this->assertStringEqualsFile(normalizeNewLine($muPluginFile), normalizeNewLine($expected));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -818,7 +819,7 @@ PHP;
 /*
 Theme Name: test
 Author: wp-browser
-Description: test 
+Description: test
 Version: 1.0
 */
 CSS;
@@ -827,8 +828,8 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertStringEqualsFile($themeStyleFile, $expectedCss);
-        $this->assertStringEqualsFile($themeIndexFile, $expectedIndex);
+        $this->assertStringEqualsFile(normalizeNewLine($themeStyleFile), normalizeNewLine($expectedCss));
+        $this->assertStringEqualsFile(normalizeNewLine($themeIndexFile), normalizeNewLine($expectedIndex));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -859,7 +860,7 @@ PHP;
 /*
 Theme Name: test
 Author: wp-browser
-Description: test 
+Description: test
 Version: 1.0
 */
 CSS;
@@ -868,9 +869,9 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertStringEqualsFile($themeStyleFile, $expectedCss);
-        $this->assertStringEqualsFile($themeIndexFile, $expectedIndex);
-        $this->assertStringEqualsFile($themeFunctionsFile, $expectedIndex);
+        $this->assertStringEqualsFile(normalizeNewLine($themeStyleFile), normalizeNewLine($expectedCss));
+        $this->assertStringEqualsFile(normalizeNewLine($themeIndexFile), normalizeNewLine($expectedIndex));
+        $this->assertStringEqualsFile(normalizeNewLine($themeFunctionsFile), normalizeNewLine($expectedIndex));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -755,7 +755,7 @@ Description: foo
 
 echo 'Hello world';
 PHP;
-        $this->assertEquals(normalizeNewLine(file_get_contents($pluginFile)), normalizeNewLine($expected));
+        $this->assertEquals(normalizeNewLine($expected), normalizeNewLine(file_get_contents($pluginFile)));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -790,7 +790,7 @@ Description: Test mu-plugin 1
 echo 'Hello world';
 PHP;
 
-        $this->assertEquals(normalizeNewLine(file_get_contents($muPluginFile)), normalizeNewLine($expected));
+        $this->assertEquals(normalizeNewLine($expected), normalizeNewLine(file_get_contents($muPluginFile)));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -829,8 +829,8 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertEquals(normalizeNewLine(file_get_contents($themeStyleFile)), normalizeNewLine($expectedCss));
-        $this->assertEquals(normalizeNewLine(file_get_contents($themeIndexFile)), normalizeNewLine($expectedIndex));
+        $this->assertEquals(normalizeNewLine($expectedCss), normalizeNewLine(file_get_contents($themeStyleFile)));
+        $this->assertEquals(normalizeNewLine($expectedIndex), normalizeNewLine(file_get_contents($themeIndexFile)));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -870,9 +870,9 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertEquals(normalizeNewLine(file_get_contents($themeStyleFile)), normalizeNewLine($expectedCss));
-        $this->assertEquals(normalizeNewLine(file_get_contents($themeIndexFile)), normalizeNewLine($expectedIndex));
-        $this->assertEquals(normalizeNewLine(file_get_contents($themeFunctionsFile)), normalizeNewLine($expectedIndex));
+        $this->assertEquals(normalizeNewLine($expectedCss), normalizeNewLine(file_get_contents($themeStyleFile)));
+        $this->assertEquals(normalizeNewLine($expectedIndex), normalizeNewLine(file_get_contents($themeIndexFile)));
+        $this->assertEquals(normalizeNewLine($expectedIndex), normalizeNewLine(file_get_contents($themeFunctionsFile)));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -755,7 +755,7 @@ Description: foo
 
 echo 'Hello world';
 PHP;
-        $this->assertStringEqualsFile(normalizeNewLine($pluginFile), normalizeNewLine($expected));
+        $this->assertEquals(normalizeNewLine(file_get_contents($pluginFile)), normalizeNewLine($expected));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -789,7 +789,8 @@ Description: Test mu-plugin 1
 
 echo 'Hello world';
 PHP;
-        $this->assertStringEqualsFile(normalizeNewLine($muPluginFile), normalizeNewLine($expected));
+
+        $this->assertEquals(normalizeNewLine(file_get_contents($muPluginFile)), normalizeNewLine($expected));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -828,8 +829,8 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertStringEqualsFile(normalizeNewLine($themeStyleFile), normalizeNewLine($expectedCss));
-        $this->assertStringEqualsFile(normalizeNewLine($themeIndexFile), normalizeNewLine($expectedIndex));
+        $this->assertEquals(normalizeNewLine(file_get_contents($themeStyleFile)), normalizeNewLine($expectedCss));
+        $this->assertEquals(normalizeNewLine(file_get_contents($themeIndexFile)), normalizeNewLine($expectedIndex));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 
@@ -869,9 +870,9 @@ CSS;
 <?php echo 'Hello world';
 PHP;
 
-        $this->assertStringEqualsFile(normalizeNewLine($themeStyleFile), normalizeNewLine($expectedCss));
-        $this->assertStringEqualsFile(normalizeNewLine($themeIndexFile), normalizeNewLine($expectedIndex));
-        $this->assertStringEqualsFile(normalizeNewLine($themeFunctionsFile), normalizeNewLine($expectedIndex));
+        $this->assertEquals(normalizeNewLine(file_get_contents($themeStyleFile)), normalizeNewLine($expectedCss));
+        $this->assertEquals(normalizeNewLine(file_get_contents($themeIndexFile)), normalizeNewLine($expectedIndex));
+        $this->assertEquals(normalizeNewLine(file_get_contents($themeFunctionsFile)), normalizeNewLine($expectedIndex));
 
         $sut->_after($this->prophesize(TestInterface::class)->reveal());
 


### PR DESCRIPTION
Upon downloading a fresh copy of wp-browser and trying to run it's tests on Windows environment, unit tests fails because of different new line carriages between Unix and Windows environments. This PR normalizes the new line bytecodes of strings before comparison in tests/unit/Codeception/Module/WPFileSystemTest.

Before:
![mintty_2018-11-04_03-12-50](https://user-images.githubusercontent.com/9341686/47960277-8e209080-dfdf-11e8-94e3-a083b51766dd.png)

After:
![mintty_2018-11-04_03-13-49](https://user-images.githubusercontent.com/9341686/47960284-a98b9b80-dfdf-11e8-8fc9-92e3d6dcfd89.png)
