### PR TITLE
fix(DbDump): Correctly handle URL replacement in SQL arrays.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "vlucas/phpdotenv": "^3.0"
   },
   "require-dev": {
-    "mikey179/vfsStream": "^1.6",
-    "ofbeaton/console-tester": "^1.1"
+    "mikey179/vfsStream": "^1.6"
   },
   "autoload": {
     "psr-4": {

--- a/src/tad/WPBrowser/Module/Support/DbDump.php
+++ b/src/tad/WPBrowser/Module/Support/DbDump.php
@@ -28,7 +28,11 @@ class DbDump
             return [];
         }
 
-        return array_map([$this, 'replaceSiteDomainInSqlString'], $sql);
+        $delimiter = md5(uniqid('delim', true));
+        $joined = implode($delimiter, $sql);
+        $replaced = $this->replaceSiteDomainInSqlString($joined);
+
+        return explode($delimiter, $replaced);
     }
 
     /**
@@ -44,7 +48,11 @@ class DbDump
             return [];
         }
 
-        return array_map([$this, 'replaceSiteDomainInMultisiteSqlString'], $sql);
+        $delimiter = md5(uniqid('delim', true));
+        $joined = implode($delimiter, $sql);
+        $replaced = $this->replaceSiteDomainInMultisiteSqlString($joined);
+
+        return explode($delimiter, $replaced);
     }
 
     /**


### PR DESCRIPTION
The previous version of the replacement was weak and relying on the specific `INSERT` format used by
wp-cli. This version should be a bit more robust of different SQL dump generation formats and handle
them correctly.