### PR TITLE
fix(WPLoader): Delay initialization until SUITE_INIT when only loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/node_modules
 docs/_book
 tests/_support/_generated
 composer.lock
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
   email: false
 
 matrix:
-  fast_finish: true
   include:
     - php: '5.6'
       env: CODECEPTION_VERSION="^2.5"

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ ci_script:
 	codecept run wpfunctional
 	codecept run wploadersuite
 	codecept run wpmodule
+	codecept run wploader_wpdb_interaction
 
 # Restarts the project containers.
 ci_docker_restart:

--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -219,7 +219,7 @@ class WPLoader extends Module
      */
     protected function ensureWPRoot($wpRootFolder)
     {
-        if ( ! file_exists($wpRootFolder . DIRECTORY_SEPARATOR . 'wp-settings.php')) {
+        if (! file_exists($wpRootFolder . DIRECTORY_SEPARATOR . 'wp-settings.php')) {
             throw new ModuleConfigException(
                 __CLASS__,
                 "\nThe path `{$wpRootFolder}` is not pointing to a valid WordPress installation folder."
@@ -252,15 +252,15 @@ class WPLoader extends Module
     protected function ensureDbModuleCompat()
     {
         $interference_candidates = ['Db', 'WPDb'];
-        $allModules              = $this->moduleContainer->all();
+        $allModules = $this->moduleContainer->all();
         foreach ($interference_candidates as $moduleName) {
-            if ( ! $this->moduleContainer->hasModule($moduleName)) {
+            if (! $this->moduleContainer->hasModule($moduleName)) {
                 continue;
             }
             /** @var \Codeception\Module $module */
-            $module         = $allModules[$moduleName];
+            $module = $allModules[$moduleName];
             $cleanup_config = $module->_getConfig('cleanup');
-            if ( ! empty($cleanup_config)) {
+            if (! empty($cleanup_config)) {
                 throw new ModuleConflictException(
                     __CLASS__,
                     "{$moduleName}\nThe WP Loader module is being used together with the {$moduleName} module: "
@@ -290,7 +290,7 @@ class WPLoader extends Module
 
         require_once dirname(dirname(__DIR__)) . '/includes/functions.php';
 
-        if ( ! empty($this->config['loadOnly'])) {
+        if (! empty($this->config['loadOnly'])) {
             $this->bootstrapWP();
         } else {
             $this->installAndBootstrapInstallation();
@@ -332,12 +332,12 @@ class WPLoader extends Module
         ];
 
         foreach ($constants as $key => $value) {
-            if ( ! defined($key)) {
+            if (! defined($key)) {
                 define($key, $value);
             }
         }
 
-        if ( ! defined('WP_PLUGIN_DIR') && ! empty($this->config['pluginsFolder'])) {
+        if (! defined('WP_PLUGIN_DIR') && ! empty($this->config['pluginsFolder'])) {
             define('WP_PLUGIN_DIR', $this->getPluginsFolder());
         }
     }
@@ -351,12 +351,12 @@ class WPLoader extends Module
     protected function loadConfigFile($folder = null)
     {
         $folder = $folder ?: codecept_root_dir();
-        $frags  = $this->config['configFile'];
-        $frags  = is_array($frags) ?: [$frags];
+        $frags = $this->config['configFile'];
+        $frags = is_array($frags) ?: [$frags];
         foreach ($frags as $frag) {
-            if ( ! empty($frag)) {
+            if (! empty($frag)) {
                 $configFile = Utils::findHereOrInParent($frag, $folder);
-                if ( ! file_exists($configFile)) {
+                if (! file_exists($configFile)) {
                     throw new ModuleConfigException(
                         __CLASS__,
                         "\nConfig file `{$frag}` could not be found in WordPress root folder or above."
@@ -385,7 +385,7 @@ class WPLoader extends Module
             $path = empty($this->config['pluginsFolder']) ? WP_PLUGIN_DIR
                 : realpath($this->getWpRootFolder() . Utils::unleadslashit($this->config['pluginsFolder']));
 
-            if ( ! file_exists($path)) {
+            if (! file_exists($path)) {
                 throw new ModuleConfigException(
                     __CLASS__,
                     "The path to the plugins folder ('{$path}') doesn't exist."
@@ -436,15 +436,15 @@ class WPLoader extends Module
 
         $current_site = new \stdClass;
 
-        if ( ! empty($wpdb->get_results("SHOW TABLES LIKE '{$wpdb->prefix}blogs'"))) {
-            $query                   = "SELECT domain, path  FROM {$wpdb->prefix}blogs WHERE blog_id = 1 AND site_id = 1";
-            $data                    = $wpdb->get_row($query);
-            $current_site->domain    = $data->domain;
-            $current_site->path      = $data->path;
+        if (! empty($wpdb->get_results("SHOW TABLES LIKE '{$wpdb->prefix}blogs'"))) {
+            $query = "SELECT domain, path  FROM {$wpdb->prefix}blogs WHERE blog_id = 1 AND site_id = 1";
+            $data = $wpdb->get_row($query);
+            $current_site->domain = $data->domain;
+            $current_site->path = $data->path;
             $current_site->site_name = ucfirst($data->domain);
         } else {
             $site_url = $wpdb->get_var("SELECT option_value FROM {$wpdb->options} WHERE option_name = 'siteurl'");
-            if ( ! empty($site_url)) {
+            if (! empty($site_url)) {
                 $current_site->domain = parse_url($site_url, PHP_URL_HOST);
                 if ($port = parse_url($site_url, PHP_URL_PORT)) {
                     $current_site->domain .= ":{$port}";
@@ -455,7 +455,7 @@ class WPLoader extends Module
             $current_site->path = '/';
         }
         $current_site->site_name = ucfirst($current_site->domain);
-        $current_site->id        = 1;
+        $current_site->id = 1;
     }
 
     protected function installAndBootstrapInstallation()
@@ -463,7 +463,7 @@ class WPLoader extends Module
         $this->setActivePlugins();
         $this->_setActiveTheme();
 
-        if ( ! $this->requiresIsolatedInstallation()) {
+        if (! $this->requiresIsolatedInstallation()) {
             tests_add_filter('muplugins_loaded', [$this, '_loadPlugins']);
             tests_add_filter('wp_install', [$this, '_activatePlugins'], 100);
             tests_add_filter(
@@ -488,7 +488,7 @@ class WPLoader extends Module
             return;
         }
 
-        if ( ! empty($GLOBALS['wp_tests_options']['active_plugins'])) {
+        if (! empty($GLOBALS['wp_tests_options']['active_plugins'])) {
             $GLOBALS['wp_tests_options']['active_plugins'] = array_merge(
                 $GLOBALS['wp_tests_options']['active_plugins'],
                 $this->config['plugins']
@@ -508,15 +508,15 @@ class WPLoader extends Module
             return;
         }
 
-        if ( ! is_array($this->config['theme'])) {
-            $template   = $this->config['theme'];
+        if (! is_array($this->config['theme'])) {
+            $template = $this->config['theme'];
             $stylesheet = $this->config['theme'];
         } else {
-            $template   = reset($this->config['theme']);
+            $template = reset($this->config['theme']);
             $stylesheet = end($this->config['theme']);
         }
 
-        $GLOBALS['wp_tests_options']['template']   = $template;
+        $GLOBALS['wp_tests_options']['template'] = $template;
         $GLOBALS['wp_tests_options']['stylesheet'] = $stylesheet;
 
         codecept_debug('Set template to [' . $template . '] and stylesheet to [' . $stylesheet . ']');
@@ -532,7 +532,7 @@ class WPLoader extends Module
         }
 
         foreach ($this->config['bootstrapActions'] as $action) {
-            if ( ! is_callable($action)) {
+            if (! is_callable($action)) {
                 do_action($action);
             } else {
                 call_user_func($action);
@@ -542,8 +542,8 @@ class WPLoader extends Module
 
     public function _switchTheme()
     {
-        if ( ! empty($this->config['theme'])) {
-            $stylesheet    = is_array($this->config['theme']) ?
+        if (! empty($this->config['theme'])) {
+            $stylesheet = is_array($this->config['theme']) ?
                 end($this->config['theme'])
                 : $this->config['theme'];
             $functionsFile = $this->wp->WP_CONTENT_DIR() . '/themes/' . $stylesheet . '/functions.php';
@@ -585,10 +585,10 @@ class WPLoader extends Module
             return;
         }
         $pluginsPath = $this->getPluginsFolder() . DIRECTORY_SEPARATOR;
-        $plugins     = $this->config['plugins'];
+        $plugins = $this->config['plugins'];
         foreach ($plugins as $plugin) {
             $path = $pluginsPath . $plugin;
-            if ( ! file_exists($path)) {
+            if (! file_exists($path)) {
                 throw new ModuleConfigException(
                     __CLASS__,
                     "The '{$plugin}' plugin file was not found in the {$pluginsPath} directory; "
@@ -650,7 +650,7 @@ class WPLoader extends Module
         if ($moduleContainer->hasModule('WPDb') || $moduleContainer->hasModule('Db')) {
             $dbModule = $moduleContainer->hasModule('WPDb') ? 'WPDb' : 'Db';
             $lines [] = '';
-            $lines[]  = "It looks like, alongside the WPLoader module, you are using the {$dbModule} one.";
+            $lines[] = "It looks like, alongside the WPLoader module, you are using the {$dbModule} one.";
             if (empty($this->config['loadOnly'])) {
                 $lines[] = 'Since the `WPLoader::loadOnly` parameter is not set or set to `false` both the '
                            . "WPLoader module and the {$dbModule} one are trying to populate the database.";

--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -2,15 +2,17 @@
 
 namespace Codeception\Module;
 
+use Codeception\Events;
 use Codeception\Exception\ModuleConfigException;
 use Codeception\Exception\ModuleConflictException;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Module;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use tad\WPBrowser\Adapters\WP;
 use tad\WPBrowser\Filesystem\Utils;
+use tad\WPBrowser\Module\Traits\Delayable;
+use tad\WPBrowser\Module\Traits\EventListener;
 use tad\WPBrowser\Module\WPLoader\FactoryStore;
 
 /**
@@ -28,6 +30,8 @@ use tad\WPBrowser\Module\WPLoader\FactoryStore;
  */
 class WPLoader extends Module
 {
+
+    use EventListener;
 
     public static $includeInheritedActions = true;
 
@@ -151,6 +155,12 @@ class WPLoader extends Module
      * @var bool
      */
     protected $wpDidLoadCorrectly = false;
+    /**
+     * An array of the database populating modules found in the module container.
+     *
+     * @var Module[]
+     */
+    protected $dbModules;
 
     /**
      * @var WP
@@ -181,47 +191,26 @@ class WPLoader extends Module
 
     protected function initialize()
     {
-        if (empty($this->config['loadOnly'])) {
-            // let's make sure *Db Module is either not running or properly configured if we have to run alongside it
-            $this->ensureDbModuleCompat();
-        }
-
-        /*
-         * @todo Populate the db if *Db module is available.
-         * @body WPLoader will fail and exit if `loadOnly` and the database is not setup.
-         */
-
         $this->ensureWPRoot($this->getWpRootFolder());
 
         // WordPress  will deal with database connection errors
         $this->wpBootstrapFile = dirname(dirname(__DIR__)) . '/includes/bootstrap.php';
-        $this->loadWordPress();
-    }
 
-    protected function ensureDbModuleCompat()
-    {
-        $interference_candidates = ['Db', 'WPDb'];
-        $allModules              = $this->moduleContainer->all();
-        foreach ($interference_candidates as $moduleName) {
-            if (!$this->moduleContainer->hasModule($moduleName)) {
-                continue;
-            }
-            /** @var \Codeception\Module $module */
-            $module         = $allModules[$moduleName];
-            $cleanup_config = $module->_getConfig('cleanup');
-            if (!empty($cleanup_config)) {
-                throw new ModuleConflictException(
-                    __CLASS__,
-                    "{$moduleName}\nThe WP Loader module is being used together with the {$moduleName} module: "
-                    . "the {$moduleName} module should have the 'cleanup' parameter set to 'false' not to interfere "
-                    . "with the WP Loader module."
-                );
-            }
+        if (empty($this->config['loadOnly'])) {
+            // Any *Db Module should either not be running or properly configured if this has to run alongside it.
+            $this->ensureDbModuleCompat();
+        } else {
+            $this->debug('WPLoader module will load WordPress when all other modules initialized.');
+            $this->addAction(Events::SUITE_INIT, [$this, '_loadWordpress'], 99);
+
+            return;
         }
+
+        $this->_loadWordpress();
     }
 
     /**
-     * @param string $wpRootFolder
+     * @param  string  $wpRootFolder
      *
      * @throws \Codeception\Exception\ModuleConfigException If the specified
      *                                                      WordPress root
@@ -230,7 +219,7 @@ class WPLoader extends Module
      */
     protected function ensureWPRoot($wpRootFolder)
     {
-        if (!file_exists($wpRootFolder . DIRECTORY_SEPARATOR . 'wp-settings.php')) {
+        if ( ! file_exists($wpRootFolder . DIRECTORY_SEPARATOR . 'wp-settings.php')) {
             throw new ModuleConfigException(
                 __CLASS__,
                 "\nThe path `{$wpRootFolder}` is not pointing to a valid WordPress installation folder."
@@ -260,6 +249,28 @@ class WPLoader extends Module
         return $this->wpRootFolder;
     }
 
+    protected function ensureDbModuleCompat()
+    {
+        $interference_candidates = ['Db', 'WPDb'];
+        $allModules              = $this->moduleContainer->all();
+        foreach ($interference_candidates as $moduleName) {
+            if ( ! $this->moduleContainer->hasModule($moduleName)) {
+                continue;
+            }
+            /** @var \Codeception\Module $module */
+            $module         = $allModules[$moduleName];
+            $cleanup_config = $module->_getConfig('cleanup');
+            if ( ! empty($cleanup_config)) {
+                throw new ModuleConflictException(
+                    __CLASS__,
+                    "{$moduleName}\nThe WP Loader module is being used together with the {$moduleName} module: "
+                    . "the {$moduleName} module should have the 'cleanup' parameter set to 'false' not to interfere "
+                    . "with the WP Loader module."
+                );
+            }
+        }
+    }
+
     /**
      * Loads WordPress calling the bootstrap file
      *
@@ -267,7 +278,7 @@ class WPLoader extends Module
      * original automated testing bootstrap file and taking charge of replacing
      * the original "wp-tests-config.php" file in setting up the globals.
      */
-    protected function loadWordPress()
+    public function _loadWordpress()
     {
         $this->defineGlobals();
 
@@ -279,7 +290,7 @@ class WPLoader extends Module
 
         require_once dirname(dirname(__DIR__)) . '/includes/functions.php';
 
-        if (!empty($this->config['loadOnly'])) {
+        if ( ! empty($this->config['loadOnly'])) {
             $this->bootstrapWP();
         } else {
             $this->installAndBootstrapInstallation();
@@ -321,19 +332,19 @@ class WPLoader extends Module
         ];
 
         foreach ($constants as $key => $value) {
-            if (!defined($key)) {
+            if ( ! defined($key)) {
                 define($key, $value);
             }
         }
 
-        if (!defined('WP_PLUGIN_DIR') && !empty($this->config['pluginsFolder'])) {
+        if ( ! defined('WP_PLUGIN_DIR') && ! empty($this->config['pluginsFolder'])) {
             define('WP_PLUGIN_DIR', $this->getPluginsFolder());
         }
     }
 
     /**
-     * @param string $folder = null The absolute path to the WordPress root
-     *                       installation folder.
+     * @param  string  $folder  = null The absolute path to the WordPress root
+     *                          installation folder.
      *
      * @throws ModuleConfigException
      */
@@ -343,9 +354,9 @@ class WPLoader extends Module
         $frags  = $this->config['configFile'];
         $frags  = is_array($frags) ?: [$frags];
         foreach ($frags as $frag) {
-            if (!empty($frag)) {
+            if ( ! empty($frag)) {
                 $configFile = Utils::findHereOrInParent($frag, $folder);
-                if (!file_exists($configFile)) {
+                if ( ! file_exists($configFile)) {
                     throw new ModuleConfigException(
                         __CLASS__,
                         "\nConfig file `{$frag}` could not be found in WordPress root folder or above."
@@ -374,7 +385,7 @@ class WPLoader extends Module
             $path = empty($this->config['pluginsFolder']) ? WP_PLUGIN_DIR
                 : realpath($this->getWpRootFolder() . Utils::unleadslashit($this->config['pluginsFolder']));
 
-            if (!file_exists($path)) {
+            if ( ! file_exists($path)) {
                 throw new ModuleConfigException(
                     __CLASS__,
                     "The path to the plugins folder ('{$path}') doesn't exist."
@@ -392,12 +403,26 @@ class WPLoader extends Module
         $this->ensureServerVars();
 
         register_shutdown_function([$this, '_wordpressExitHandler']);
-        include_once Utils::untrailslashit($this->wpRootFolder).'/wp-load.php';
+        include_once Utils::untrailslashit($this->wpRootFolder) . '/wp-load.php';
         $this->wpDidLoadCorrectly = true;
 
         $this->setupCurrentSite();
         $this->factoryStore = new FactoryStore();
         $this->factoryStore->setupFactories();
+    }
+
+    protected function ensureServerVars()
+    {
+        $serverDefaults = [
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'HTTP_HOST'       => getenv('WP_DOMAIN') ? getenv('WP_DOMAIN') : $this->config['domain'],
+        ];
+
+        foreach ($serverDefaults as $key => $value) {
+            if (empty($_SERVER[$key])) {
+                $_SERVER[$key] = $value;
+            }
+        }
     }
 
     /**
@@ -411,15 +436,15 @@ class WPLoader extends Module
 
         $current_site = new \stdClass;
 
-        if (!empty($wpdb->get_results("SHOW TABLES LIKE '{$wpdb->prefix}blogs'"))) {
-            $query = "SELECT domain, path  FROM {$wpdb->prefix}blogs WHERE blog_id = 1 AND site_id = 1";
+        if ( ! empty($wpdb->get_results("SHOW TABLES LIKE '{$wpdb->prefix}blogs'"))) {
+            $query                   = "SELECT domain, path  FROM {$wpdb->prefix}blogs WHERE blog_id = 1 AND site_id = 1";
             $data                    = $wpdb->get_row($query);
             $current_site->domain    = $data->domain;
             $current_site->path      = $data->path;
             $current_site->site_name = ucfirst($data->domain);
         } else {
             $site_url = $wpdb->get_var("SELECT option_value FROM {$wpdb->options} WHERE option_name = 'siteurl'");
-            if (!empty($site_url)) {
+            if ( ! empty($site_url)) {
                 $current_site->domain = parse_url($site_url, PHP_URL_HOST);
                 if ($port = parse_url($site_url, PHP_URL_PORT)) {
                     $current_site->domain .= ":{$port}";
@@ -438,7 +463,7 @@ class WPLoader extends Module
         $this->setActivePlugins();
         $this->_setActiveTheme();
 
-        if (!$this->requiresIsolatedInstallation()) {
+        if ( ! $this->requiresIsolatedInstallation()) {
             tests_add_filter('muplugins_loaded', [$this, '_loadPlugins']);
             tests_add_filter('wp_install', [$this, '_activatePlugins'], 100);
             tests_add_filter(
@@ -463,7 +488,7 @@ class WPLoader extends Module
             return;
         }
 
-        if (!empty($GLOBALS['wp_tests_options']['active_plugins'])) {
+        if ( ! empty($GLOBALS['wp_tests_options']['active_plugins'])) {
             $GLOBALS['wp_tests_options']['active_plugins'] = array_merge(
                 $GLOBALS['wp_tests_options']['active_plugins'],
                 $this->config['plugins']
@@ -483,7 +508,7 @@ class WPLoader extends Module
             return;
         }
 
-        if (!is_array($this->config['theme'])) {
+        if ( ! is_array($this->config['theme'])) {
             $template   = $this->config['theme'];
             $stylesheet = $this->config['theme'];
         } else {
@@ -507,7 +532,7 @@ class WPLoader extends Module
         }
 
         foreach ($this->config['bootstrapActions'] as $action) {
-            if (!is_callable($action)) {
+            if ( ! is_callable($action)) {
                 do_action($action);
             } else {
                 call_user_func($action);
@@ -517,7 +542,7 @@ class WPLoader extends Module
 
     public function _switchTheme()
     {
-        if (!empty($this->config['theme'])) {
+        if ( ! empty($this->config['theme'])) {
             $stylesheet    = is_array($this->config['theme']) ?
                 end($this->config['theme'])
                 : $this->config['theme'];
@@ -556,14 +581,14 @@ class WPLoader extends Module
      */
     public function _loadPlugins()
     {
-        if (empty($this->config['plugins']) || !defined('WP_PLUGIN_DIR')) {
+        if (empty($this->config['plugins']) || ! defined('WP_PLUGIN_DIR')) {
             return;
         }
         $pluginsPath = $this->getPluginsFolder() . DIRECTORY_SEPARATOR;
         $plugins     = $this->config['plugins'];
         foreach ($plugins as $plugin) {
             $path = $pluginsPath . $plugin;
-            if (!file_exists($path)) {
+            if ( ! file_exists($path)) {
                 throw new ModuleConfigException(
                     __CLASS__,
                     "The '{$plugin}' plugin file was not found in the {$pluginsPath} directory; "
@@ -596,24 +621,10 @@ class WPLoader extends Module
         return $this->factoryStore;
     }
 
-    protected function ensureServerVars()
-    {
-        $serverDefaults = [
-            'SERVER_PROTOCOL' => 'HTTP/1.1',
-            'HTTP_HOST'       => getenv('WP_DOMAIN') ? getenv('WP_DOMAIN') : $this->config['domain'],
-        ];
-
-        foreach ($serverDefaults as $key => $value) {
-            if (empty($_SERVER[$key])) {
-                $_SERVER[$key] = $value;
-            }
-        }
-    }
-
     /**
      * Returns a closure to handle the exit of WordPress during the bootstrap process.
      *
-     * @param OutputInterface|null  $output An output stream.
+     * @param  OutputInterface|null  $output  An output stream.
      */
     public function _wordpressExitHandler(OutputInterface $output = null)
     {
@@ -626,12 +637,12 @@ class WPLoader extends Module
         $lines = [
             'The WPLoader module could not correctly load WordPress.',
             'If you do not see any other output beside this, probably a call to `die` or `exit` might have been'
-            .' made while loading WordPress files.',
+            . ' made while loading WordPress files.',
             'There are a number of reasons why this might happen and the most common is an empty, incomplete or'
-            .' incoherent database status.',
+            . ' incoherent database status.',
             '',
             'E.g. you are trying to bootstrap WordPress as multisite on a database that does not contain '
-            .'multisite tables.'
+            . 'multisite tables.',
         ];
 
         $moduleContainer = $this->moduleContainer;
@@ -639,40 +650,52 @@ class WPLoader extends Module
         if ($moduleContainer->hasModule('WPDb') || $moduleContainer->hasModule('Db')) {
             $dbModule = $moduleContainer->hasModule('WPDb') ? 'WPDb' : 'Db';
             $lines [] = '';
-            $lines[] = "It looks like, alongside the WPLoader module, you are using the {$dbModule} one.";
+            $lines[]  = "It looks like, alongside the WPLoader module, you are using the {$dbModule} one.";
             if (empty($this->config['loadOnly'])) {
                 $lines[] = 'Since the `WPLoader::loadOnly` parameter is not set or set to `false` both the '
-                    ."WPLoader module and the {$dbModule} one are trying to populate the database.";
+                           . "WPLoader module and the {$dbModule} one are trying to populate the database.";
                 $lines[] = "If you want to fill the database with a dump then keep using the {$dbModule} "
-                    .'module but set the `WPLoader::loadOnly` parameter to `true` and make sure that, '
-                    ."in the suite configuration file, in the `modules` section, the {$dbModule} module comes"
-                    .' before the WPLoader one.';
+                           . 'module but set the `WPLoader::loadOnly` parameter to `true` and make sure that, '
+                           . "in the suite configuration file, in the `modules` section, the {$dbModule} module comes"
+                           . ' before the WPLoader one.';
                 $lines[] = '';
                 $lines[] = 'If you are, instead, trying to run integration tests you do not probably need the'
-                    ." {$dbModule} module or should set the `populate` and `cleanup` arguments to `false`";
+                           . " {$dbModule} module or should set the `populate` and `cleanup` arguments to `false`";
             } else {
                 $lines[] = 'Since the `WPLoader::loadOnly` parameter is set to `true` the WPLoader module'
-                    .' will not try to populate the database.';
+                           . ' will not try to populate the database.';
                 $lines[] = "The database should be populated from a dump using the {$dbModule} modules.";
                 $lines[] = 'Make sure the SQL dump you\'re trying to use is not empty and correct for the kind '
-                    .'of installation you are trying to test.';
-                $lines[] = 'Make also sure that, in the suite configuration file, in the `modules` section, '.
-                    "the {$dbModule} modules comes before the WPLoader one.".
-                    $lines[] = '';
+                           . 'of installation you are trying to test.';
+                $lines[] = 'Make also sure that, in the suite configuration file, in the `modules` section, ' .
+                           "the {$dbModule} modules comes before the WPLoader one." .
+                           $lines[] = '';
                 $lines[] = 'If you are, instead, trying to run integration tests you do not probably need the'
-                    ." {$dbModule} module or should set the `populate` and `cleanup` arguments to `false` and "
-                    .'set the `WPLoader::loadOnly` parameter to `false` to let the WPLoader module populate the'
-                    .' database for you.';
+                           . " {$dbModule} module or should set the `populate` and `cleanup` arguments to `false` and "
+                           . 'set the `WPLoader::loadOnly` parameter to `false` to let the WPLoader module populate the'
+                           . ' database for you.';
             }
             $lines[] = 'Find out more about this at '
-                .'https://wpbrowser.wptestkit.dev/summary/modules/wploader'
-                .'#wploader-to-only-bootstrap-wordpress';
+                       . 'https://wpbrowser.wptestkit.dev/summary/modules/wploader'
+                       . '#wploader-to-only-bootstrap-wordpress';
         } else {
             $lines[] = 'Since the `WPLoader::loadOnly` parameter is set to `true` the WPLoader module'
-                .' will not try to populate the database.';
+                       . ' will not try to populate the database.';
             $lines[] = 'The database should be populated from a dump using the WPDb/Db modules.';
         }
 
-        $output->writeln('<error>'.implode(PHP_EOL, $lines).'</error>');
+        $output->writeln('<error>' . implode(PHP_EOL, $lines) . '</error>');
+    }
+
+    protected function loadWordPressAfterDb()
+    {
+        $matchingModule = null;
+
+        $this->debug(sprintf(
+            'Module WPLoader will initialize after module %s initialized',
+            $matchingModule
+        ));
+
+        $this->_loadWordpress();
     }
 }

--- a/src/tad/WPBrowser/Module/Traits/EventListener.php
+++ b/src/tad/WPBrowser/Module/Traits/EventListener.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Provides methods to interact with Codeception `run` command event dispatch stack.
+ *
+ * @package tad\WPBrowser\Module\Traits
+ */
+
+namespace tad\WPBrowser\Module\Traits;
+
+use Codeception\Application;
+use Codeception\Exception\ModuleException;
+use Codeception\Util\ReflectionHelper;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * Trait EventListener
+ *
+ * @package tad\WPBrowser\Module\Traits
+ * @property \Codeception\Lib\ModuleContainer $moduleContainer
+ */
+trait EventListener
+{
+
+    /**
+     * The `run` command event dispatcher.
+     *
+     * @var EventDispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * Adds a callback to be performed on a global runner event..
+     *
+     * @param  string    $event     The event to run the callback on.
+     * @param  callable  $callback  The callback to run on the event.
+     * @param  int       $priority  The priority that will be assigned to the callback in the context of the event.
+     *
+     * @throws \Codeception\Exception\ModuleException
+     */
+    protected function addAction($event, $callback, $priority = 0)
+    {
+        $this->getEventDispatcher()->addListener($event, $callback, $priority);
+    }
+
+    /**
+     * Returns the instance of the event dispatcher used by the `codecept run` command instance.
+     *
+     * @return EventDispatcher The event dispatcher instance used by the `run` command.
+     *
+     * @throws ModuleException If the global application instance is not a Codeception\Application instance; if the
+     *                         `run` command dispatcher property cannot be accessed or is not an `EventDispatcher`
+     *                         instance.
+     */
+    protected function getEventDispatcher()
+    {
+        if ($this->dispatcher instanceof EventDispatcher) {
+            return $this->dispatcher;
+        }
+
+        /** @var \Codeception\Application $app */
+        global $app;
+
+        if ( ! $app instanceof Application) {
+            throw new ModuleException(
+                $this,
+                'Global `app` object is either empty or not an instance of the \Codeception\Application class.'
+            );
+        }
+
+        /** @var \Codeception\Command\Run $runCommand */
+        $runCommand = $app->find('run');
+
+        try {
+            /** @var \Codeception\Codecept $codecept */
+            $codecept   = ReflectionHelper::readPrivateProperty($runCommand, 'codecept');
+            $dispatcher = $codecept->getDispatcher();
+        } catch (\ReflectionException $e) {
+            throw new ModuleException(
+                $this,
+                'Could not get the value of the `\Codeception\Command\Run::$codecept` property, message:' .
+                $e->getMessage()
+            );
+        }
+        if ( ! $dispatcher instanceof EventDispatcher) {
+            throw new ModuleException($this, sprintf(
+                '\\Codeception\\Codecept::$eventDispatcher property is not an instance of %s; value is instead: %s',
+                EventDispatcher::class,
+                print_r($dispatcher, true)
+            ));
+        }
+
+        $this->dispatcher = $dispatcher;
+
+        return $this->dispatcher;
+    }
+}

--- a/src/tad/WPBrowser/Module/Traits/EventListener.php
+++ b/src/tad/WPBrowser/Module/Traits/EventListener.php
@@ -60,7 +60,7 @@ trait EventListener
         /** @var \Codeception\Application $app */
         global $app;
 
-        if ( ! $app instanceof Application) {
+        if (! $app instanceof Application) {
             throw new ModuleException(
                 $this,
                 'Global `app` object is either empty or not an instance of the \Codeception\Application class.'
@@ -81,7 +81,7 @@ trait EventListener
                 $e->getMessage()
             );
         }
-        if ( ! $dispatcher instanceof EventDispatcher) {
+        if (! $dispatcher instanceof EventDispatcher) {
             throw new ModuleException($this, sprintf(
                 '\\Codeception\\Codecept::$eventDispatcher property is not an instance of %s; value is instead: %s',
                 EventDispatcher::class,

--- a/tests/wploader_wpdb_interaction.suite.dist.yml
+++ b/tests/wploader_wpdb_interaction.suite.dist.yml
@@ -4,6 +4,7 @@ modules:
         - \Helper\Wploader_wpdb_interaction
         - WPLoader
         - WPDb
+        - Asserts
     config:
         WPDb:
             dsn: 'mysql:host=%DB_HOST%;dbname=%DB_NAME%'

--- a/tests/wploader_wpdb_interaction/LoadingCest.php
+++ b/tests/wploader_wpdb_interaction/LoadingCest.php
@@ -1,0 +1,16 @@
+<?php
+use Wploader_wpdb_interactionTester as Tester;
+
+class LoadingCest
+{
+
+    /**
+     * It should be able to load WordPress correctly in concert with other Db modules
+     *
+     * @test
+     */
+    public function should_be_able_to_load_word_press_correctly_in_concert_with_other_db_modules(Tester $I)
+    {
+        $I->assertTrue(function_exists('wp'));
+    }
+}


### PR DESCRIPTION
When the `loadOnly` configuration parameter is set to `true` then the WPLoader module will not try to install and initialize WordPress in the database. This makes the module inherently dependant, in its WordPress bootstrap phase, from other *Db modules setting up a valid, initial, database fixture. If the module initializes before those other modules did then WordPress will `exit` not finding a valid installation. This fix makes it so that the module will hook on the `run` command event bus to initialize after all other modules did.