### PR TITLE
fix(WPUnit testcase template): make sure scaffold testcase is PHPUnit 8+ compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   },
   "require-dev": {
     "erusev/parsedown": "^1.7",
-    "lucatume/codeception-snapshot-assertions": "^0.1",
+    "lucatume/codeception-snapshot-assertions": "^0.2.0",
     "mikey179/vfsstream": "^1.6",
     "squizlabs/php_codesniffer": "^3.4",
     "victorjonsson/markdowndocs": "dev-master"

--- a/src/Codeception/Lib/Generator/WPUnit.php
+++ b/src/Codeception/Lib/Generator/WPUnit.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace Codeception\Lib\Generator;
 
 use Codeception\Lib\Generator\Shared\Classname;
+use Codeception\TestCase\WPTestCase;
 use Codeception\Util\Shared\Namespaces;
 use Codeception\Util\Template;
 
@@ -19,28 +21,31 @@ class WPUnit extends AbstractGenerator implements GeneratorInterface
 class {{name}}Test extends {{baseClass}}
 {
 
-    public function setUp()
+    public function setUp(){{voidReturnType}}
     {
-        // before
+        // Before...
         parent::setUp();
 
-        // your set up methods here
+        // Your set up methods here.
     }
 
-    public function tearDown()
+    public function tearDown(){{voidReturnType}}
     {
-        // your tear down methods here
+        // Your tear down methods here.
 
-        // then
+        // Then...
         parent::tearDown();
     }
 
-    // tests
-    public function testMe()
+    // Tests
+    public function test_it_works()
     {
+        \$post = static::factory()->post->create_and_get();
+        
+        \$this->assertInstanceOf(\\WP_Post::class, \$post);
     }
-
 }
+
 EOF;
 
     public function __construct($settings, $name, $baseClass)
@@ -54,9 +59,18 @@ EOF;
     {
         $ns = $this->getNamespaceHeader($this->settings['namespace'] . '\\' . $this->name);
 
+        $phpunitSeries = getenv('WPBROWSER_PHPUNIT_SERIES');
+        if (empty($phpunitSeries) && class_exists(WPTestCase::class)) {
+            $phpunitSeries = getenv('WPBROWSER_PHPUNIT_SERIES');
+        }
+        $voidReturnType = version_compare($phpunitSeries, '8.0', '<') ?
+            ''
+            : ': void';
+
         return (new Template($this->template))->place('namespace', $ns)
             ->place('baseClass', $this->baseClass)
             ->place('name', $this->getShortClassName($this->name))
+            ->place('voidReturnType', $voidReturnType)
             ->produce();
     }
 }

--- a/src/tad/WPBrowser/Compat/PHPUnit/Base/Testcase.php
+++ b/src/tad/WPBrowser/Compat/PHPUnit/Base/Testcase.php
@@ -10,6 +10,7 @@
 namespace tad\WPBrowser\Compat\PHPUnit;
 
 use Codeception\Test\Unit;
+use Codeception\TestCase\WPTestCase;
 
 /**
  * Class Testcase

--- a/src/tad/WPBrowser/phpunit-compat.php
+++ b/src/tad/WPBrowser/phpunit-compat.php
@@ -11,7 +11,9 @@ if (class_exists('PHPUnit\Runner\Version')) {
     $phpunitSeries = '5.0';
 }
 
-if (version_compare($phpunitSeries, '8.0.0', '<')) {
+putenv('WPBROWSER_PHPUNIT_SERIES=' . $phpunitSeries);
+
+if (version_compare($phpunitSeries, '8.0', '<')) {
     require_once __DIR__ . '/Compat/PHPUnit/Base/Testcase.php';
 } else {
     require_once __DIR__ . '/Compat/PHPUnit/Version8/Testcase.php';

--- a/tests/unit/Codeception/Lib/Generator/WPUnitTest.php
+++ b/tests/unit/Codeception/Lib/Generator/WPUnitTest.php
@@ -1,0 +1,93 @@
+<?php namespace Codeception\Lib\Generator;
+
+use Codeception\TestCase\WPTestCase;
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+
+class WPUnitTest extends \Codeception\Test\Unit
+{
+
+    use SnapshotAssertions;
+
+    /**
+     * A backup of the current PHPUnit Series env var.
+     * @var array|false|string
+     */
+    protected $phpunitSeriesEnv;
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    /**
+     * It should scaffold PHPUnit v8 compatible code on series 8
+     *
+     * @test
+     * @dataProvider phpUnitEq8Series
+     */
+    public function should_scaffold_php_unit_v_8_code_on_series_8($series)
+    {
+        $this->setPhpUnitSeriesTo('8.0');
+        $settings = ['namespace' => 'Acme'];
+        $name = 'SomeClass';
+        $generator = new WPUnit($settings, $name, WPTestCase::class);
+
+        $code = $generator->produce();
+
+        $this->assertMatchesCodeSnapshot($code, 'php');
+    }
+
+    protected function setPhpUnitSeriesTo($series)
+    {
+        putenv("WPBROWSER_PHPUNIT_SERIES={$series}");
+    }
+
+    public function phpUnitLt8Series()
+    {
+        return [
+            '5.5' => ['5.5'],
+            '5.5.5' => ['5.5'],
+            '6.2' => ['6.2'],
+            '6.2.3' => ['6.2'],
+            '7.5' => ['7.5'],
+            '7.5.6' => ['7.5'],
+        ];
+    }
+
+    /**
+     * It should scaffold PHPUnit lt 8.0 compatible code on series lt 8
+     *
+     * @test
+     * @dataProvider phpUnitLt8Series
+     */
+    public function should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8($series)
+    {
+        $this->setPhpUnitSeriesTo($series);
+        $settings = ['namespace' => 'Acme'];
+        $name = 'SomeClass';
+        $generator = new WPUnit($settings, $name, WPTestCase::class);
+
+        $code = $generator->produce();
+
+        $this->assertMatchesCodeSnapshot($code, 'php');
+    }
+
+    public function phpUnitEq8Series()
+    {
+        return [
+            '8.0' => ['8.0'],
+            '8.0.4' => ['8.0.4'],
+            '8.1' => ['8.1'],
+            '8.1.6' => ['8.1.6'],
+        ];
+    }
+
+    protected function _before()
+    {
+        $this->phpunitSeriesEnv = getenv('WPBROWSER_PHPUNIT_SERIES');
+    }
+
+    protected function _after()
+    {
+        putenv('WPBROWSER_PHPUNIT_SERIES='.$this->phpunitSeriesEnv);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__5.5.5__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__5.5.5__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__5.5__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__5.5__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__6.2.3__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__6.2.3__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__6.2__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__6.2__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__7.5.6__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__7.5.6__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__7.5__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_lt_8_0_compatible_code_on_series_lt_8__7.5__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp()
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown()
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.0.4__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.0.4__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.0__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.0__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.1.6__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.1.6__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}

--- a/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.1__0.snapshot.php
+++ b/tests/unit/Codeception/Lib/Generator/__snapshots__/WPUnitTest__should_scaffold_php_unit_v_8_code_on_series_8__8.1__0.snapshot.php
@@ -1,0 +1,30 @@
+<?php
+namespace Acme;
+
+class SomeClassTest extends Codeception\TestCase\WPTestCase
+{
+
+    public function setUp(): void
+    {
+        // Before...
+        parent::setUp();
+
+        // Your set up methods here.
+    }
+
+    public function tearDown(): void
+    {
+        // Your tear down methods here.
+
+        // Then...
+        parent::tearDown();
+    }
+
+    // Tests
+    public function test_it_works()
+    {
+        $post = static::factory()->post->create_and_get();
+        
+        $this->assertInstanceOf(\WP_Post::class, $post);
+    }
+}


### PR DESCRIPTION
This fix adds a check on the generation of the WPUnit testcase template to make sure the testcase
will be PHPUnit 8+ compatible if using PHPUnit 8+.

fix #241