### PR TITLE
fix(WPLoader.php): load wp at the end of SUITE_BEFORE event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [2.2.13] 2019-06-13;
+### Fixed
+- when the `WPLoader` module is set to `loadOnly` mode and used in conjunction with a `*Db` module delay its load after all other modules ran their `_beforeSuite` action; this tackles an issua only partially resolved in `2.2.8` (thanks @Luc45)
+
 ## [2.2.12] 2019-06-10;
 ### Fixed
 - make sure Cron is disabled while `WPLoader` module is installing WordPress in isolation (default mode)
@@ -898,7 +902,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Reference to ModuleConfigException class in WPLoader class.
 
-[unreleased]: https://github.com/lucatume/wp-browser/compare/2.2.12...HEAD
+[unreleased]: https://github.com/lucatume/wp-browser/compare/2.2.13...HEAD
+[2.2.13]: https://github.com/lucatume/wp-browser/compare/2.2.12...2.2.13:
 [2.2.12]: https://github.com/lucatume/wp-browser/compare/2.2.11...2.2.12:
 [2.2.11]: https://github.com/lucatume/wp-browser/compare/2.2.10...2.2.11:
 [2.2.10]: https://github.com/lucatume/wp-browser/compare/2.2.9...2.2.10

--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -217,7 +217,7 @@ class WPLoader extends Module
             $this->ensureDbModuleCompat();
         } else {
             $this->debug('WPLoader module will load WordPress when all other modules initialized.');
-            $this->addAction(Events::SUITE_INIT, [$this, '_loadWordpress'], 99);
+            $this->addAction(Events::SUITE_BEFORE, [$this, '_loadWordpress'], 0);
 
             return;
         }
@@ -296,11 +296,7 @@ class WPLoader extends Module
     }
 
     /**
-     * Loads WordPress calling the bootstrap file
-     *
-     * This method does little but wrapping preparing the global space for the
-     * original automated testing bootstrap file and taking charge of replacing
-     * the original "wp-tests-config.php" file in setting up the globals.
+     * Loads WordPress calling the bootstrap file.
      */
     public function _loadWordpress()
     {


### PR DESCRIPTION
This commit fixes an issue partially tackled in 2.2.8 to delay WordPress loading, by the WPLoader
module, if a *Db module is loaded in the same suite. The solution implemented in 2.2.8 was not
complete and robust enough to completely take care of the issue; this commit makes sure WordPress
will be loaed on a populated db

Thanks @Luc45 for finding this out.