### PR TITLE
Use %TEST_SITE_WP_URL% instead of %WP_URL%

### DIFF
--- a/src/Codeception/Template/Wpbrowser.php
+++ b/src/Codeception/Template/Wpbrowser.php
@@ -599,7 +599,7 @@ modules:
             populate: true
             cleanup: true
             waitlock: 10
-            url: '%WP_URL%'
+            url: '%TEST_SITE_WP_URL%'
             urlReplacement: true
             tablePrefix: '%TEST_SITE_TABLE_PREFIX%'
         WPBrowser:


### PR DESCRIPTION
When generating the standard suite configurations, there is only one occurence of %WP_URL%, but many of %TEST_SITE_WP_URL%. As %WP_URL% is not set automatically in the env file, this should be changed.