### PR TITLE
fix(WPTestCase): setup Codeception Unit to provide Codeception Unit facilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,20 @@ COMPOSE_FILE ?= docker-compose.yml
 CODECEPTION_VERSION ?= "^2.5"
 PROJECT := $(shell basename ${CURDIR})
 
-.PHONY: wp_dump cs_sniff cs_fix cs_fix_n_sniff ci_before_install ci_before_script ci_docker_restart ci_install ci_local_prepare ci_run ci_script pre_commit
+.PHONY: wp_dump \
+	cs_sniff \
+	cs_fix  \
+	cs_fix_n_sniff  \
+	ci_before_install  \
+	ci_before_script \
+	ci_docker_restart \
+	ci_install  \
+	ci_local_prepare \
+	ci_run  \
+	ci_script \
+	pre_commit \
+	require_codeception_2.5 \
+	require_codeception_3
 
 define wp_config_extra
 if ( filter_has_var( INPUT_SERVER, 'HTTP_HOST' ) ) {
@@ -253,3 +266,11 @@ wp_dump:
 		/project/tests/_data/dump.sql
 
 pre_commit: lint cs_sniff
+
+require_codeception_2.5:
+	rm -rf composer.lock vendor/codeception vendor/phpunit vendor/sebastian \
+		&& composer require codeception/codeception:^2.5
+
+require_codeception_3:
+	rm -rf composer.lock vendor/codeception vendor/phpunit vendor/sebastian \
+		&& composer require codeception/codeception:^3.0

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "wp-cli/wp-cli-bundle": ">=2.0 <3.0.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "<8.2.0",
     "erusev/parsedown": "^1.7",
     "lucatume/codeception-snapshot-assertions": "^0.2",
     "mikey179/vfsstream": "^1.6",

--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -171,8 +171,6 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
 
     public function _setUp()
     {
-        Unit::_setup();
-
         set_time_limit(0);
 
         if (!self::$ignore_files) {
@@ -207,6 +205,17 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
         $this->start_transaction();
         $this->expectDeprecated();
         add_filter('wp_die_handler', array($this, 'get_wp_die_handler'));
+
+        /**
+         * After WordPress has been initialized in the test context initialize the Codeception Unit test case.
+         * Check on what methods `\Codeception\Test\Unit` provides to call the correct one depending on the PHPUnit and
+         * Codeception versions.
+         */
+        if (method_exists(Unit::class, '_setUp')) {
+            Unit::_setup();
+        } elseif (method_exists(Unit::class, 'setUp')) {
+            Unit::setUp();
+        }
     }
 
     public function scan_user_uploads()

--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -2,6 +2,8 @@
 namespace Codeception\TestCase;
 
 // phpcs:disable
+use Codeception\Test\Unit;
+
 if (!class_exists('WP_UnitTest_Factory')) {
     require_once dirname(dirname(dirname(__FILE__))) . '/includes/factory.php';
 }
@@ -169,6 +171,8 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
 
     public function _setUp()
     {
+        Unit::_setup();
+
         set_time_limit(0);
 
         if (!self::$ignore_files) {

--- a/tests/wploadersuite/UnitExtensionTest.php
+++ b/tests/wploadersuite/UnitExtensionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Codeception\Stub\Expected;
+
+class UnitExtensionTest extends \Codeception\TestCase\WPTestCase
+{
+    /**
+     * It should allow accessing the tester property
+     *
+     * @test
+     */
+    public function should_allow_accessing_the_tester_property()
+    {
+        $this->assertInstanceOf(WploaderTester::class, $this->tester);
+    }
+
+    /**
+     * It should allow using Codeception stubs
+     *
+     * @test
+     */
+    public function should_allow_using_codeception_stubs()
+    {
+        $stub = $this->make(WP_User::class, ['get_site_id' => 23]);
+
+        $this->assertEquals(23, $stub->get_site_id());
+    }
+
+    /**
+     * It should allow using codeception dummys
+     *
+     * @test
+     */
+    public function should_allow_using_codeception_dummys()
+    {
+        $stub = $this->makeEmpty(WP_User::class);
+
+        $this->assertNull($stub->get_site_id());
+    }
+
+    /**
+     * It should allow using codeception partial mocks
+     *
+     * @test
+     */
+    public function should_allow_using_codeception_partial_mocks()
+    {
+        $realUser = new WP_User;
+        $stub = $this->makeEmptyExcept(WP_User::class, 'get_site_id');
+
+        $this->assertEquals($realUser->get_site_id(), $stub->get_site_id());
+    }
+
+    /**
+     * It should allow using Codeception stubs with constructors
+     *
+     * @test
+     */
+    public function should_allow_using_codeception_stubs_with_constructors()
+    {
+        $realUser = static::factory()->user->create_and_get();
+        $stub = $this->construct(
+            WP_User::class,
+            ['id' => $realUser->ID, 'name' => $realUser->display_name],
+            ['to_array' => 23]
+        );
+
+        $this->assertEquals(23, $stub->to_array());
+    }
+
+    /**
+     * It should allow using Codeception stubs with constructor and empty method
+     *
+     * @test
+     */
+    public function should_allow_using_codeception_stubs_with_constructor_and_empty_method()
+    {
+        $realUser = static::factory()->user->create_and_get();
+        $stub = $this->constructEmpty(
+            WP_User::class,
+            ['id' => $realUser->ID, 'name' => $realUser->display_name]
+        );
+
+        $this->assertNull($stub->to_array());
+    }
+}


### PR DESCRIPTION
This commit makes sure `Codeception\Test\Unit::_setup` method is called before the Core-suite-like setup is started in the `WPTestCase` class. This will initialize the Unit testing facilities (e.g. `$this->tester`) to anyone using the test-case.

fix #262