### PR TITLE
Wait until DB is actually initialized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ docker_pull:
 		'mariadb:latest' \
 		'wordpress:php5.6' \
 		'andthensome/alpine-surge-bash' \
+		'martin/wait' \
 	); \
 	for image in "$${images[@]}"; do \
 		docker pull "$$image"; \
@@ -92,8 +93,8 @@ phpstan: src
 ci_setup_db:
 	# Start just the database container.
 	docker-compose -f docker/${COMPOSE_FILE} up -d db
-	# Give the DB container some time to initialize.
-	sleep 10
+	# Wait until DB is initialized.
+	docker-compose -f docker/${COMPOSE_FILE} run --rm waiter
 	# Create the databases that will be used in the tests.
 	docker-compose -f docker/${COMPOSE_FILE} exec db bash -c 'mysql -u root -e "create database if not exists test_site"'
 	docker-compose -f docker/${COMPOSE_FILE} exec db bash -c 'mysql -u root -e "create database if not exists test"'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,3 +45,10 @@ services:
       - ./../vendor/wordpress/wordpress:/var/www/html
       # bind the root folder to the /project folder
       - ./..:/project
+
+  waiter:
+    image: martin/wait
+    depends_on:
+      - db
+    environment:
+      - db_TCP=tcp://db:3306


### PR DESCRIPTION
While running `Makefile` on my end I encountered that sometimes 10 seconds timeout is not enough. Or sometimes I run `ci_setup_db` when DB contianer is already running, and I wait 10 seconds for no purpose. So it's better to wait until DB is actually initialized.
The `wait` image size is only few MB.