### PR TITLE
build(Makefile) use gnu-sed syntax in hosts script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,17 +250,15 @@ gitbook_build: docker/gitbook/id duplicate_gitbook_files module_docs gitbook_ins
 	rm -rf ${CURDIR}/docs/site/bin
 
 remove_hosts_entries:
-	echo "Removing project ${PROJECT} hosts entries..."
-	sudo sed -n -i .orig '/## ${PROJECT} project - start ##/{x;d;};1h;1!{x;p;};$${x;p;}' /etc/hosts
-	sudo sed -i .orig '/^## ${PROJECT} project - start ##/,/## ${PROJECT} project - end ##$$/d' /etc/hosts
+	echo "Removing project ${PROJECT} hosts entries (and backing up /etc/hosts to /etc/hosts.orig...)"
+	sudo sed -i.orig '/^## ${PROJECT} project - Start ##/,/## ${PROJECT} project - End ##$$/d' /etc/hosts
 
 sync_hosts_entries: remove_hosts_entries
 	echo "Adding project ${project} hosts entries..."
 	set -o allexport &&  source .env.testing &&  set +o allexport && \
-	sudo -- sh -c "echo '' >> /etc/hosts" && \
-	sudo -- sh -c "echo '## ${PROJECT} project - start ##' >> /etc/hosts" && \
+	sudo -- sh -c "echo '## ${PROJECT} project - Start ##' >> /etc/hosts" && \
 	sudo -- sh -c "echo '127.0.0.1 $${TEST_HOSTS}' >> /etc/hosts" && \
-	sudo -- sh -c "echo '## ${PROJECT} project - end ##' >> /etc/hosts"
+	sudo -- sh -c "echo '## ${PROJECT} project - End ##' >> /etc/hosts"
 
 # Export a dump of WordPressdatabase to the _data folder of the project.
 wp_dump:


### PR DESCRIPTION
fix #286

This commit changes the Makefile `sync_host_entries` and
`remove_host_entries` scripts to make them compatible with gnu-sed (they
were compatible with Mac OS version of `sed` binary before).
The `/etc/hosts` file is backed up in the `/etc/hosts.orig` file before
any operation.
This commit simplifies the script too by removing the first line in the
`remove_host_entries` target, as suggested by @karser in the issue
(https://github.com/lucatume/wp-browser/issues/286#issue-476823319).