### PR TITLE
Add support for "seeing" WP CLI output and exit codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [2.2.30] 2019-10-14;
+### Added
+- `dontSeeInShellOutput`, `seeInShellOutput`, `seeResultCodeIs`, `seeResultCodeIsNot` and `seeShellOutputMatches` methods to `WPCLI` module (thanks @TimothyBJacobs)b
+
 ## [2.2.29] 2019-09-24;
 ### Fixed
 - `wpbrowser` template class to make sure the environment file name is respected when set to different values
@@ -1158,4 +1162,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [2.2.27]: https://github.com/lucatume/wp-browser/compare/2.2.26...2.2.27
 [2.2.28]: https://github.com/lucatume/wp-browser/compare/2.2.27...2.2.28
 [2.2.29]: https://github.com/lucatume/wp-browser/compare/2.2.28...2.2.29
-[unreleased]: https://github.com/lucatume/wp-browser/compare/2.2.29...HEAD
+[2.2.30]: https://github.com/lucatume/wp-browser/compare/2.2.29...2.2.30
+[unreleased]: https://github.com/lucatume/wp-browser/compare/2.2.30...HEAD

--- a/docs/modules/WPCLI.md
+++ b/docs/modules/WPCLI.md
@@ -98,6 +98,21 @@ modules:
 		<li>
 			<a href="#clitostring">cliToString</a>
 		</li>
+		<li>
+			<a href="#dontseeinshelloutput">dontSeeInShellOutput</a>
+		</li>
+		<li>
+			<a href="#seeinshelloutput">seeInShellOutput</a>
+		</li>
+		<li>
+			<a href="#seeresultcodeis">seeResultCodeIs</a>
+		</li>
+		<li>
+			<a href="#seeresultcodeisnot">seeResultCodeIsNot</a>
+		</li>
+		<li>
+			<a href="#seeshelloutputmatches">seeShellOutputMatches</a>
+		</li>
 	</ul>
 </nav>
 
@@ -166,6 +181,71 @@ modules:
 <h4>Parameters</h4>
 <ul>
 <li><code>string/array</code> <strong>$userCommand</strong> - The string of command and parameters as it would be passed to wp-cli minus <code>wp</code>.</li></ul>
+  
+
+<h3>dontSeeInShellOutput</h3>
+
+<hr>
+
+<p>Checks that output from last command doesn't contain text.</p>
+<pre><code class="language-php">    // Return the current site administrator email, using string command format.
+    $I-&gt;cli('plugin list --status=active');
+    $I-&gt;dontSeeInShellOutput('my-inactive/plugin.php');</code></pre>
+<h4>Parameters</h4>
+<ul>
+<li><code>string</code> <strong>$text</strong> - The text to assert is not in the output.</li></ul>
+  
+
+<h3>seeInShellOutput</h3>
+
+<hr>
+
+<p>Checks that output from last command contains text.</p>
+<pre><code class="language-php">
+    // Return the current site administrator email, using string command format.
+    $I-&gt;cli('option get admin_email');</code></pre>
+<h4>Parameters</h4>
+<ul>
+<li><code>string</code> <strong>$text</strong> - The text to assert is in the output.</li></ul>
+  
+
+<h3>seeResultCodeIs</h3>
+
+<hr>
+
+<p>Checks the result code from the last command.</p>
+<pre><code class="language-php">    // Return the current site administrator email, using string command format.
+    $I-&gt;cli('option get admin_email');
+    $I-&gt;seeResultCodeIs(0);</code></pre>
+<h4>Parameters</h4>
+<ul>
+<li><code>int</code> <strong>$code</strong> - The desired result code.</li></ul>
+  
+
+<h3>seeResultCodeIsNot</h3>
+
+<hr>
+
+<p>Checks the result code from the last command.</p>
+<pre><code class="language-php">    // Return the current site administrator email, using string command format.
+    $I-&gt;cli('invalid command');
+    $I-&gt;seeResultCodeIsNot(0);</code></pre>
+<h4>Parameters</h4>
+<ul>
+<li><code>int</code> <strong>$code</strong> - The result code the command should not have exited with.</li></ul>
+  
+
+<h3>seeShellOutputMatches</h3>
+
+<hr>
+
+<p>Checks that output from the last command matches a given regular expression.</p>
+<pre><code class="language-php">
+    // Return the current site administrator email, using string command format.
+    $I-&gt;cli('option get admin_email');</code></pre>
+<h4>Parameters</h4>
+<ul>
+<li><code>string</code> <strong>$regex</strong> - The regex pattern, including delimiters, to assert the output matches against.</li></ul>
 
 
 *This class extends \Codeception\Module*

--- a/src/Codeception/Module/WPCLI.php
+++ b/src/Codeception/Module/WPCLI.php
@@ -313,7 +313,14 @@ class WPCLI extends Module
     /**
      * Checks that output from last command contains text.
      *
-     * @param string $text
+     * @param string $text The text to assert is in the output.
+     *
+     * @example
+     * ```php
+     * // Return the current site administrator email, using string command format.
+     * $I->cli('option get admin_email');
+     * $I->seeInShellOutput('admin@example.org');
+     * ```
      */
     public function seeInShellOutput($text)
     {
@@ -323,7 +330,14 @@ class WPCLI extends Module
     /**
      * Checks that output from last command doesn't contain text.
      *
-     * @param string $text
+     * @param string $text The text to assert is not in the output.
+     *
+     * @example
+     * ```php
+     * // Return the current site administrator email, using string command format.
+     * $I->cli('plugin list --status=active');
+     * $I->dontSeeInShellOutput('my-inactive/plugin.php');
+     * ```
      */
     public function dontSeeInShellOutput($text)
     {
@@ -333,7 +347,14 @@ class WPCLI extends Module
     /**
      * Checks that output from the last command matches a given regular expression.
      *
-     * @param string $regex
+     * @param string $regex The regex pattern, including delimiters, to assert the output matches against.
+     *
+     * @example
+     * ```php
+     * // Return the current site administrator email, using string command format.
+     * $I->cli('option get admin_email');
+     * $I->seeShellOutputMatches('/^\S+@\S+$/');
+     * ```
      */
     public function seeShellOutputMatches($regex)
     {
@@ -343,7 +364,14 @@ class WPCLI extends Module
     /**
      * Checks the result code from the last command.
      *
-     * @param int $code
+     * @param int $code The desired result code.
+     *
+     * @example
+     * ```php
+     * // Return the current site administrator email, using string command format.
+     * $I->cli('option get admin_email');
+     * $I->seeResultCodeIs(0);
+     * ```
      */
     public function seeResultCodeIs($code)
     {
@@ -353,7 +381,14 @@ class WPCLI extends Module
     /**
      * Checks the result code from the last command.
      *
-     * @param int $code
+     * @param int $code The result code the command should not have exited with.
+     *
+     * @example
+     * ```php
+     * // Return the current site administrator email, using string command format.
+     * $I->cli('invalid command');
+     * $I->seeResultCodeIsNot(0);
+     * ```
      */
     public function seeResultCodeIsNot($code)
     {

--- a/src/Codeception/Module/WPCLI.php
+++ b/src/Codeception/Module/WPCLI.php
@@ -75,6 +75,14 @@ class WPCLI extends Module
      * @var int|float|null
      */
     protected $timeout;
+    /**
+     * @var string
+     */
+    protected $lastOutput;
+    /**
+     * @var int
+     */
+    protected $lastResultCode;
 
     /**
      * WPCLI constructor.
@@ -303,6 +311,56 @@ class WPCLI extends Module
     }
 
     /**
+     * Checks that output from last command contains text.
+     *
+     * @param string $text
+     */
+    public function seeInShellOutput($text)
+    {
+        \Codeception\PHPUnit\TestCase::assertStringContainsString($text, $this->lastOutput);
+    }
+
+    /**
+     * Checks that output from last command doesn't contain text.
+     *
+     * @param string $text
+     */
+    public function dontSeeInShellOutput($text)
+    {
+        \PHPUnit\Framework\Assert::assertNotContains($text, $this->lastOutput);
+    }
+
+    /**
+     * Checks that output from the last command matches a given regular expression.
+     *
+     * @param string $regex
+     */
+    public function seeShellOutputMatches($regex)
+    {
+        \PHPUnit\Framework\Assert::assertRegExp($regex, $this->lastOutput);
+    }
+
+    /**
+     * Checks the result code from the last command.
+     *
+     * @param int $code
+     */
+    public function seeResultCodeIs($code)
+    {
+        $this->assertEquals($this->lastResultCode, $code, "result code is $code");
+    }
+
+    /**
+     * Checks the result code from the last command.
+     *
+     * @param int $code
+     */
+    public function seeResultCodeIsNot($code)
+    {
+        $this->assertNotEquals($this->lastResultCode, $code, "result code is $code");
+    }
+
+    /**
      * Builds the process environment from the configuration options.
      *
      * @return array An associative array of environment.
@@ -367,6 +425,9 @@ class WPCLI extends Module
 
             $this->debugSection('command exception', $e->getMessage());
 
+            $this->lastOutput     = '';
+            $this->lastResultCode = 1;
+
             return ['',1];
         }
 
@@ -385,6 +446,9 @@ class WPCLI extends Module
         $this->debugSection(' status', $status);
 
         $this->evaluateStatus($output, $status);
+
+        $this->lastOutput     = $output;
+        $this->lastResultCode = $status;
 
         return [$output, $status];
     }

--- a/tests/climodule/cli/SeeMethodsCest.php
+++ b/tests/climodule/cli/SeeMethodsCest.php
@@ -1,32 +1,33 @@
 <?php
+use ClimoduleTester as Tester;
 
 class SeeMethodsCest
 {
-    public function it_should_see_correct_output(Wpcli_moduleTester $I)
+    public function it_should_see_correct_output(Tester $I)
     {
         $I->cli('eval "echo \'hi\';"');
         $I->seeInShellOutput( 'hi' );
     }
 
-    public function it_should_not_see_correct_output(Wpcli_moduleTester $I)
+    public function it_should_not_see_correct_output(Tester $I)
     {
         $I->cli('eval "echo \'hi\';"');
         $I->dontSeeInShellOutput( 'hello' );
     }
 
-    public function it_should_see_correct_output_matches(Wpcli_moduleTester $I)
+    public function it_should_see_correct_output_matches(Tester $I)
     {
         $I->cli('eval "echo \'hi\';"');
-        $I->seeShellOutputMatches( '\w+' );
+        $I->seeShellOutputMatches( '/\w+/' );
     }
 
-    public function it_should_see_correct_result_code(Wpcli_moduleTester $I)
+    public function it_should_see_correct_result_code(Tester $I)
     {
         $I->cli('eval "echo \'hi\';"');
         $I->seeResultCodeIs(0);
     }
 
-    public function it_should_not_see_correct_result_code(Wpcli_moduleTester $I)
+    public function it_should_not_see_correct_result_code(Tester $I)
     {
         $I->cli('eval "echo \'hi\';"');
         $I->seeResultCodeIsNot(1);

--- a/tests/wpcli_module/SeeMethodsCest.php
+++ b/tests/wpcli_module/SeeMethodsCest.php
@@ -1,0 +1,34 @@
+<?php
+
+class SeeMethodsCest
+{
+    public function it_should_see_correct_output(Wpcli_moduleTester $I)
+    {
+        $I->cli('eval "echo \'hi\';"');
+        $I->seeInShellOutput( 'hi' );
+    }
+
+    public function it_should_not_see_correct_output(Wpcli_moduleTester $I)
+    {
+        $I->cli('eval "echo \'hi\';"');
+        $I->dontSeeInShellOutput( 'hello' );
+    }
+
+    public function it_should_see_correct_output_matches(Wpcli_moduleTester $I)
+    {
+        $I->cli('eval "echo \'hi\';"');
+        $I->seeShellOutputMatches( '\w+' );
+    }
+
+    public function it_should_see_correct_result_code(Wpcli_moduleTester $I)
+    {
+        $I->cli('eval "echo \'hi\';"');
+        $I->seeResultCodeIs(0);
+    }
+
+    public function it_should_not_see_correct_result_code(Wpcli_moduleTester $I)
+    {
+        $I->cli('eval "echo \'hi\';"');
+        $I->seeResultCodeIsNot(1);
+    }
+}


### PR DESCRIPTION
Smaller documentation additions on top of `TimothyBJacobs:add-wp-cli-see-methods` PR (#320) to fix #309.