### PR TITLE
Fix issues when `$cache` is not public.

### DIFF
--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -126,8 +126,14 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
         $wp_object_cache->group_ops = array();
         $wp_object_cache->stats = array();
         $wp_object_cache->memcache_debug = array();
-        $wp_object_cache->cache = array();
-        if (method_exists($wp_object_cache, '__remoteset')) {
+
+        if ( $wp_object_cache instanceof \WP_Object_Cache ) {
+        	$wp_object_cache->flush();
+        } else if ( isset( $wp_object_cache->cache ) ) {
+	        $wp_object_cache->cache = [];
+        }
+
+	    if (method_exists($wp_object_cache, '__remoteset')) {
             $wp_object_cache->__remoteset();
         }
         wp_cache_flush();


### PR DESCRIPTION
By default the variable is not public, some providers might have it available as public and on default WordPress installation there's no `object-cache` present however if present the default type of access to the variable is set to private, the intent used to clear this variable is via the `flush()` method.