### PR TITLE
fix(WPLoader) table handling during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Changed
+
+- an issue where tables created by plugins during the WordPress installation managed by the `WPLoader` module would be dropped; default behaviour changed to emptying the tables, fixes #356
+
 ## [2.4.0] 2020-04-10;
 
 ### Added

--- a/docs/modules/WPLoader.md
+++ b/docs/modules/WPLoader.md
@@ -19,6 +19,7 @@ When configured to only load WordPress (`loadOnly: true`) then any database oper
 * `dbPassword` *required* - The password of the database used by the WordPress installation, same as `DB_PASSWORD` constant.
 * `loadOnly` - defaults to `false`; whether to only load WordPress, without bootstrapping a fresh installation for tests or not. Read more in the ["Using WPLoader in acceptance and functional tests"](#using-wploader-in-acceptance-and-functional-tests) section. If this parameter is set to `true` the following parameters will not apply.
 * `isolatedInstall` - defaults to `true`, whether to install and bootstrap the WordPress installation in a secondary PHP thread for thread safety or not. Maintained for back-compatibility purposes with wp-browser first versions: to get a replica of the bootstrap process used by [WordPress Core PHPUnit tests]() leave this to `true`.
+* `installationTableHandling` - defaults to `empty`; it controls how tables created by WordPress and plugins will be handled during the installation of WordPress during tests. By default tables will be emptied of any content, but some plugins might require tables to be dropped before WordPress is installed and after plugins are activated (this used to be the default behavior). Supported values are `drop` to drop the tables, `empty` to just empty the tables and `let` to do nothing about the tables. If you get errors from database queries while the `WPLoader` module installs the tests, then try changing this parameter value. 
 * `wpDebug` - defaults to `true`, the value the `WP_DEBUG` constant will be set to.
 * `multisite` - defaults to `false`, the value the `MULTISITE` constant will be set to.
 * `dbCharset` - defaults to `utf8`, the value the `DB_CHARSET` constant will be set to.
@@ -70,6 +71,7 @@ When configured to only load WordPress (`loadOnly: true`) then any database oper
               dbUser: "root"
               dbPassword: "password"
               isolatedInstall: true
+              installationTableHandling: drop
               tablePrefix: "wptests_"
               domain: "wordrpess.localhost"
               adminEmail: "admin@wordpress.localhost"

--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -15,6 +15,7 @@ use tad\WPBrowser\Module\Support\WPHealthcheck;
 use tad\WPBrowser\Module\WPLoader\FactoryStore;
 use tad\WPBrowser\Traits\WithEvents;
 use tad\WPBrowser\Traits\WithWordPressFilters;
+use tad\WPBrowser\Utils\Configuration;
 
 /**
  * Class WPLoader
@@ -109,24 +110,25 @@ class WPLoader extends Module
      */
     protected $config
         = [
-            'loadOnly'         => false,
-            'isolatedInstall'  => true,
-            'wpDebug'          => true,
-            'multisite'        => false,
-            'dbCharset'        => 'utf8',
-            'dbCollate'        => '',
-            'tablePrefix'      => 'wptests_',
-            'domain'           => 'example.org',
-            'adminEmail'       => 'admin@example.org',
-            'title'            => 'Test Blog',
-            'phpBinary'        => 'php',
-            'language'         => '',
-            'configFile'       => '',
-            'pluginsFolder'    => 'wp-content/plugins',
-            'plugins'          => '',
-            'activatePlugins'  => '',
-            'bootstrapActions' => '',
-            'theme'            => '',
+            'loadOnly'                  => false,
+            'isolatedInstall'           => true,
+            'installationTableHandling' => 'empty',
+            'wpDebug'                   => true,
+            'multisite'                 => false,
+            'dbCharset'                 => 'utf8',
+            'dbCollate'                 => '',
+            'tablePrefix'               => 'wptests_',
+            'domain'                    => 'example.org',
+            'adminEmail'                => 'admin@example.org',
+            'title'                     => 'Test Blog',
+            'phpBinary'                 => 'php',
+            'language'                  => '',
+            'configFile'                => '',
+            'pluginsFolder'             => 'wp-content/plugins',
+            'plugins'                   => '',
+            'activatePlugins'           => '',
+            'bootstrapActions'          => '',
+            'theme'                     => '',
         ];
 
     /**
@@ -531,6 +533,12 @@ class WPLoader extends Module
             );
             tests_add_filter('plugins_loaded', [$this, '_switchTheme']);
         }
+
+        $installationConfiguration = new Configuration([
+            'tablesHandling' => isset($this->config['installationTableHandling']) ?
+                $this->config['installationTableHandling']
+                : 'empty'
+        ]);
 
         require_once $this->wpBootstrapFile;
 

--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Installs WordPress for running the tests and loads WordPress and the test libraries
+ *
+ * @var tad\WPBrowser\Utils\Configuration $installationConfiguration The current installation configuration.
  */
 
 use function tad\WPBrowser\vendorDir;
@@ -100,6 +102,7 @@ if (!defined('WPCEPT_ISOLATED_INSTALL') || false === WPCEPT_ISOLATED_INSTALL) {
 			'WP_PHP_BINARY' => WP_PHP_BINARY,
 			'WPLANG' => WPLANG,
 		],
+		'tablesHandling' => $installationConfiguration->get('tablesHandling','empty'),
 	];
 
 	$dirConstants = [

--- a/src/tad/WPBrowser/Environment/Configuration.php
+++ b/src/tad/WPBrowser/Environment/Configuration.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Models the configuration for a test WordPress installation like the one set up by WPLoader.
+ *
+ * @package tad\WPBrowser\Configuration
+ */
+
+namespace tad\WPBrowser\Configuration;
+
+use tad\WPBrowser\Utils\Map;
+
+/**
+ * Class TestInstallationConfiguration
+ *
+ * @package tad\WPBrowser\Configuration
+ */
+class Configuration extends Map
+{
+}

--- a/src/tad/WPBrowser/Utils/Configuration.php
+++ b/src/tad/WPBrowser/Utils/Configuration.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Models the configuration for a test WordPress installation like the one set up by WPLoader.
+ *
+ * @package tad\WPBrowser\Utils
+ */
+
+namespace tad\WPBrowser\Utils;
+
+/**
+ * Class TestInstallationConfiguration
+ *
+ * @package tad\WPBrowser\Utils
+ */
+class Configuration extends Map
+{
+}

--- a/src/tad/WPBrowser/Utils/Map.php
+++ b/src/tad/WPBrowser/Utils/Map.php
@@ -97,4 +97,18 @@ class Map implements \ArrayAccess
     {
         $this->map = $map;
     }
+
+    /**
+     * Returns a value defined in the map, falling back to a default if the value is not defined.
+     *
+     * @param string     $offset  The name of the value to return from the map.
+     * @param null|mixed $default A default value to return if the value associated with the key is not set in the map.
+     *
+     * @return mixed|null The value associated with the key in the map, or a default value if the key is not set in
+     *                    the map.
+     */
+    public function get($offset, $default = null)
+    {
+        return isset($this->map[ $offset ]) ? $this->map[ $offset ] : $default;
+    }
 }

--- a/src/tad/WPBrowser/utils.php
+++ b/src/tad/WPBrowser/utils.php
@@ -19,3 +19,4 @@ require_once __DIR__ . '/patchwork.php';
 require_once __DIR__ . '/filesystem.php';
 require_once __DIR__ . '/events.php';
 require_once __DIR__ . '/deprecated.php';
+require_once __DIR__ . '/wp.php';

--- a/src/tad/WPBrowser/wp-browser.php
+++ b/src/tad/WPBrowser/wp-browser.php
@@ -7,6 +7,8 @@
 
 namespace tad\WPBrowser;
 
+use Codeception\Configuration;
+
 /**
  * Returns the wp-browser package root directory.
  *

--- a/src/tad/WPBrowser/wp.php
+++ b/src/tad/WPBrowser/wp.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Function dedicate to WordPress interaction.
+ *
+ * @package tad\WPBrowser
+ */
+
+namespace tad\WPBrowser;
+
+function dropWpTables(\wpdb $wpdb, array $tables = null)
+{
+    $allTables = $wpdb->tables('all');
+
+    foreach ($allTables as $table => $prefixedTable) {
+        if (!in_array($prefixedTable, $tables, true)) {
+            continue;
+        }
+        $dropped = $wpdb->query("DROP TABLE {$prefixedTable} IF EXISTS ");
+
+        if ($dropped!== true) {
+            throw new \RuntimeException("Could not DROP table {$prefixedTable}: " . $wpdb->last_error);
+        }
+    }
+}
+
+function emptyWpTables(\wpdb $wpdb, array $tables = null)
+{
+    // Make sure we start from empty tables.
+    $dropList = $wpdb->get_col("show tables like '{$wpdb->prefix}%'");
+    if ($tables !== null) {
+        $dropList = array_intersect($dropList, $tables);
+    }
+
+    if (! empty($dropList)) {
+        $allTables = $wpdb->tables('all');
+        foreach ($allTables as $table => $prefixedTable) {
+            if (! in_array($prefixedTable, $dropList, true)) {
+                continue;
+            }
+            $deleted = $wpdb->query("DELETE FROM {$prefixedTable} WHERE 1=1");
+
+            if ($deleted === false) {
+                throw new \RuntimeException("Could not empty table {$prefixedTable}: " . $wpdb->last_error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
During WPLoader initial set up the following events would happen:

1. Plugins are included
2. WordPress is installed
3. Plugins are activated

While most plugins would creat custom tables during activation (3), some, e.g. WooCommerce, would create some tables at inclusion time (1).
This would cause issues as, between 1 and 2, WPLoader would drop the tables that some plugins would then look for in step 3.

This PR:

1. adds the `WPLoader.installationTableHandling` configuration parameter to support `drop` (previous default), `empty` (new default) or `let` to do nothing.
2. uses the value to handle the tables before setup
3. changes the default behavior from `drop` to `empty` 

fixes #356