### PR TITLE
Fix amOnAdminAjaxPage() with query vars

### DIFF
--- a/src/Codeception/Module/WPBrowserMethods.php
+++ b/src/Codeception/Module/WPBrowserMethods.php
@@ -347,7 +347,7 @@ trait WPBrowserMethods
     {
         $path = 'admin-ajax.php';
         if ($queryVars !== null) {
-            $path = '/' . (is_array($queryVars) ? build_query($queryVars) : ltrim($queryVars, '/'));
+            $path .= '?' . (is_array($queryVars) ? build_query($queryVars) : ltrim($queryVars, '?'));
         }
         return $this->amOnAdminPage($path);
     }

--- a/tests/unit/Codeception/Module/WordPressTest.php
+++ b/tests/unit/Codeception/Module/WordPressTest.php
@@ -173,6 +173,32 @@ class WordPressTest extends \Codeception\Test\Unit
         $this->assertEquals('/wp-admin/admin-ajax.php', $page);
     }
 
+
+    /**
+     * @test
+     * it should point to ajax file when requesting ajax page
+     */
+    public function it_should_point_to_ajax_file_when_requesting_ajax_page_with_query_vars()
+    {
+        $this->client->setHeaders(Arg::type('array'))->shouldBeCalled();
+
+        $this->config['adminPath'] = '/wp-admin';
+        $sut = $this->make_instance();
+        $sut->_isMockRequest(true);
+
+        $array_single = $sut->amOnAdminAjaxPage(['action' => 'foo_action']);
+        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action', $array_single);
+
+        $array_multiple = $sut->amOnAdminAjaxPage(['action' => 'foo_action', 'data' => 'bar_data', 'nonce' => 'baz_nonce']);
+        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $array_multiple);
+
+        $string = $sut->amOnAdminAjaxPage('foo_action&bar_data&baz_nonce');
+        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $string);
+
+        $string_with_question_mark = $sut->amOnAdminAjaxPage('?foo_action&bar_data&baz_nonce');
+        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $string_with_question_mark);
+    }
+
     /**
      * @test
      * it should point to cron file when requesting cron page

--- a/tests/unit/Codeception/Module/WordPressTest.php
+++ b/tests/unit/Codeception/Module/WordPressTest.php
@@ -187,16 +187,16 @@ class WordPressTest extends \Codeception\Test\Unit
         $sut->_isMockRequest(true);
 
         $array_single = $sut->amOnAdminAjaxPage(['action' => 'foo_action']);
-        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action', $array_single);
+        $this->assertEquals('/wp-admin/admin-ajax.php?action=foo_action', $array_single);
 
         $array_multiple = $sut->amOnAdminAjaxPage(['action' => 'foo_action', 'data' => 'bar_data', 'nonce' => 'baz_nonce']);
-        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $array_multiple);
+        $this->assertEquals('/wp-admin/admin-ajax.php?action=foo_action&data=bar_data&nonce=baz_nonce', $array_multiple);
 
-        $string = $sut->amOnAdminAjaxPage('foo_action&bar_data&baz_nonce');
-        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $string);
+        $string = $sut->amOnAdminAjaxPage('action=foo_action&data=bar_data&nonce=baz_nonce');
+        $this->assertEquals('/wp-admin/admin-ajax.php?action=foo_action&data=bar_data&nonce=baz_nonce', $string);
 
-        $string_with_question_mark = $sut->amOnAdminAjaxPage('?foo_action&bar_data&baz_nonce');
-        $this->assertEquals('/wp-admin/admin-ajax.php?foo_action&bar_data&baz_nonce', $string_with_question_mark);
+        $string_with_question_mark = $sut->amOnAdminAjaxPage('?action=foo_action&data=bar_data&nonce=baz_nonce');
+        $this->assertEquals('/wp-admin/admin-ajax.php?action=foo_action&data=bar_data&nonce=baz_nonce', $string_with_question_mark);
     }
 
     /**

--- a/tests/unit/Codeception/Module/WordPressTest.php
+++ b/tests/unit/Codeception/Module/WordPressTest.php
@@ -176,7 +176,7 @@ class WordPressTest extends \Codeception\Test\Unit
 
     /**
      * @test
-     * it should point to ajax file when requesting ajax page
+     * it should point to ajax file when requesting ajax page with query vars
      */
     public function it_should_point_to_ajax_file_when_requesting_ajax_page_with_query_vars()
     {


### PR DESCRIPTION
When using `$I->amOnAdminAjaxPage( [ 'action' => 'foo_action', 'data' => 'bar_data' ] )`, the query vars should append to `admin-ajax.php`, instead, they were overriding it.

So instead of dispatching requests to `admin-ajax.php?action=foo_action&data=bar_data`, it would try to dispatch to `/action=foo_action&data=bar_data`.

I haven't actually run these tests that I've written. I don't have the DBs and environment to run those.

This can be considered more of a bug report than a ready-to-use PR.

Thanks.