### PR TITLE
avoid fatal if 2 repos running WP Browser

### DIFF
--- a/src/tad/WPBrowser/deprecated.php
+++ b/src/tad/WPBrowser/deprecated.php
@@ -5,16 +5,17 @@
  * @package tad\WPBrowser
  */
 
-/**
- * Recursively removes a directory and all its content.
- *
- * @param string $src The absolute path to the directory to remove.
- *
- * @deprecated Since 2.3; moved to the `\tad\WPBrowser` namespace.
- *
- * @see tad\WPBrowser\rrmdir() for the replacement function.
- */
-function rrmdir($src)
-{
-    tad\WPBrowser\rrmdir($src);
+if ( ! function_exists( 'rrmdir' ) ) {
+	/**
+	 * Recursively removes a directory and all its content.
+	 *
+	 * @see        tad\WPBrowser\rrmdir() for the replacement function.
+	 * @deprecated Since 2.3; moved to the `\tad\WPBrowser` namespace.
+	 *
+	 * @param string $src The absolute path to the directory to remove.
+	 *
+	 */
+	function rrmdir( $src ) {
+		tad\WPBrowser\rrmdir( $src );
+	}
 }


### PR DESCRIPTION
Example:
> PHP Fatal error:  Cannot redeclare rrmdir() (previously declared in .../wp-content/plugins/event-tickets/vendor/lucatume/wp-browser/src/tad/WPBrowser/functions.php:42) in .../wp-content/plugins/the-events-calendar/vendor/lucatume/wp-browser/src/tad/WPBrowser/deprecated.php on line 17