### PR TITLE
Remove outdated stubs hack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,10 +59,6 @@
       "tests/_support/functions.php"
     ]
   },
-  "scripts": {
-    "post-install-cmd": "PHPStan\\WordPress\\Composer\\FixWpStubs::php73Polyfill",
-    "post-update-cmd": "PHPStan\\WordPress\\Composer\\FixWpStubs::php73Polyfill"
-  },
   "extra": {
     "_hash": "484f861f69198089cab0e642f27e5653"
   },


### PR DESCRIPTION
php-stubs/wordpress-stubs provides clean WP stubs