### PR TITLE
fix(src) set $_SERVER request time if not set

### DIFF
--- a/src/tad/WPBrowser/phpunit-compat.php
+++ b/src/tad/WPBrowser/phpunit-compat.php
@@ -14,3 +14,11 @@ if (version_compare(\Codeception\Codecept::VERSION, '3.0.0', '<')) {
         '\\tad\\WPBrowser\\Compat\\Codeception\\Unit'
     );
 }
+
+if (! isset($_SERVER['REQUEST_TIME'])) {
+    $_SERVER['REQUEST_TIME'] = time();
+}
+
+if (! isset($_SERVER['REQUEST_TIME_FLOAT'])) {
+    $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
+}


### PR DESCRIPTION
tentatively fix an issue with latest versions of PHPUnit where
`$_SERVER['REQUEST_TIME_FLOAT']` if not set.

fixes #417