### PR TITLE
Factory auto-completion when using $this->tester->factory();

### DIFF
--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -776,7 +776,7 @@ class WPLoader extends Module
      * $userId = $I->factory()->user->create(['role' => 'administrator']);
      * ```
      *
-     * @return FactoryStore A factory store, proxy to get hold of the Core suite object factories.
+     * @return \tad\WPBrowser\Module\WPLoader\FactoryStore A factory store, proxy to get hold of the Core suite object factories.
      *
      * @link https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/
      */


### PR DESCRIPTION
The generated actions end up in the `_generated` namespace after `codecept build`.

Therefore, `@return` tags in Modules should be fully qualified names, otherwise autocompletion won't be available on IDEs (tested on PHPStorm), eg:

- `$this->tester->factory()->` should give me the list of factories.
- `$this->tester->factory()->p` should suggest me "post", pressing tab would complete it

Currently, the IDE doesn't know what factory() is, therefore does not autocomplete.