### PR TITLE
Add default codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# By default, the repo is owned by the team manager
+* @ryanshoover


### PR DESCRIPTION

## Description
Adds a codeowner file so the security team can easily discern who is responsible for the repo. Per security's direction, we're assigning the team manager as the defacto owner for all code.

See [github's documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) for more about code owners.

## Impacted Areas in Application
* Github config

## Deploy Notes
This just needs merged into the default branch. It doesn't need deployed.

## Steps to Test or Reproduce
1. Just adding the file into the .github directory. No testing needed

## Random GIF
![Thanks for reviewing my code!](https://media.giphy.com/media/L0SaMZxxqMgsAJf69v/giphy.gif)
