### PR TITLE
Fix/459 haveplugin

### DIFF
--- a/src/Codeception/Module/WPFilesystem.php
+++ b/src/Codeception/Module/WPFilesystem.php
@@ -1113,7 +1113,7 @@ class WPFilesystem extends Filesystem
             $slug = basename(dirname($path));
             $dir  = dirname($fullPath);
 
-            if ( ! @mkdir($dir, 0777, true) && ! is_dir($dir)) {
+            if (!@mkdir($dir, 0777, true) && ! is_dir($dir)) {
                 throw new ModuleException(
                     __CLASS__,
                     "Could not create [{$dir}] plugin folder."

--- a/src/Codeception/Module/WPFilesystem.php
+++ b/src/Codeception/Module/WPFilesystem.php
@@ -1105,14 +1105,24 @@ class WPFilesystem extends Filesystem
     public function havePlugin($path, $code)
     {
         $fullPath = $this->config['plugins'] . unleadslashit($path);
-        $dir = dirname($fullPath);
-        if (!@mkdir($dir, 0777, true) && !is_dir($dir)) {
-            throw new ModuleException(
-                __CLASS__,
-                "Could not create [{$dir}] plugin folder."
-            );
+
+        if (strpos($path, DIRECTORY_SEPARATOR) === false) {
+            $slug    = pathinfo($fullPath, PATHINFO_FILENAME);
+            $toClean = $fullPath;
+        } else {
+            $slug = basename(dirname($path));
+            $dir  = dirname($fullPath);
+
+            if ( ! @mkdir($dir, 0777, true) && ! is_dir($dir)) {
+                throw new ModuleException(
+                    __CLASS__,
+                    "Could not create [{$dir}] plugin folder."
+                );
+            }
+
+            $toClean = $dir;
         }
-        $slug = basename(dirname($path));
+
         $code = $this->removeOpeningPhpTag($code);
         $name = $slug;
         $contents = <<<PHP
@@ -1134,7 +1144,7 @@ PHP;
             );
         }
 
-        $this->toClean[] = $dir;
+        $this->toClean[] = $toClean;
     }
 
     /**

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -827,7 +827,7 @@ PHP;
     }
 
     /**
-     * It should allow having a plugin with code
+     * It should allow having a single file plugin with code
      * @test
      */
     public function it_should_allow_having_a_single_file_plugin_with_code()

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -826,6 +826,39 @@ PHP;
         Assert::assertFileDoesNotExist($pluginFolder);
     }
 
+    /**
+     * It should allow having a plugin with code
+     * @test
+     */
+    public function it_should_allow_having_a_single_file_plugin_with_code()
+    {
+        $sut = $this->make_instance();
+
+        $pluginsFolder = $this->config['wpRootFolder'] . $this->config['plugins'];
+        $pluginFile =  $pluginsFolder . '/plugin.php';
+
+        $code = "echo 'Hello world';";
+        $sut->havePlugin('plugin.php', $code);
+
+        $this->assertFileExists($pluginFile);
+
+        $expected = <<<PHP
+<?php
+/*
+Plugin Name: plugin
+Description: plugin
+*/
+
+echo 'Hello world';
+PHP;
+        $this->assertEquals(normalizeNewLine($expected), normalizeNewLine(file_get_contents($pluginFile)));
+
+        $sut->_after($this->stubProphecy(TestInterface::class)->reveal());
+
+        Assert::assertFileDoesNotExist($pluginFile);
+        $this->assertFileExists($pluginsFolder);
+    }
+
 
     /**
      * It should allow having a mu-plugin with code


### PR DESCRIPTION
Fixes https://github.com/lucatume/wp-browser/issues/459

Essentially, it adapts `havePlugin` to be able to handle single-file plugins such as `foo.php`, cleaning up just the created file afterward. The old implementation of `havePlugin` supported only a plugin inside a folder: `foo/bar.php`.

I didn't go into making it also compatible with deeper tree structures such as `foo/bar/baz.php` as discussed on the issue https://github.com/lucatume/wp-browser/issues/459, because `havePlugin` creates a PHP file with a plugin header and contents. In WordPress, a plugin entry-file can be either a `wp-content/plugins/foo.php` or `wp-content/plugins/foo/bar.php`, never `wp-content/plugins/foo/bar/baz.php`.

Therefore I think this scenario doesn't fit the `havePlugin` function, but perhaps could be viable for a new function: `haveFileInPlugin($plugin_folder, $filename, $file_contents)`. Let me know if you think otherwise, and I can adapt this PR.

I've checked `haveMuPlugin()` as well and there was no need for modifications there, as it allows only single-files, which is fine due to the nature of mu-plugins.