### PR TITLE
PHPUnit 9.5.0 compatibility

### DIFF
--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -402,10 +402,10 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
 
     public function expectDeprecated()
     {
-        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->name
-        );
+		$annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+			get_class($this),
+			$this->name
+		);
 
         foreach (array('class', 'method') as $depth) {
             if (!empty($annotations[$depth]['expectedDeprecated'])) {

--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -402,7 +402,11 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
 
     public function expectDeprecated()
     {
-        $annotations = $this->getAnnotations();
+        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->name
+        );
+
         foreach (array('class', 'method') as $depth) {
             if (!empty($annotations[$depth]['expectedDeprecated'])) {
                 $this->expected_deprecated = array_merge(

--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -402,10 +402,10 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
 
     public function expectDeprecated()
     {
-		$annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-			get_class($this),
-			$this->name
-		);
+        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->name
+        );
 
         foreach (array('class', 'method') as $depth) {
             if (!empty($annotations[$depth]['expectedDeprecated'])) {

--- a/src/includes/speed-trap-listener.php
+++ b/src/includes/speed-trap-listener.php
@@ -319,7 +319,10 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      */
     protected function getSlowThreshold(PHPUnit_Framework_TestCase $test)
     {
-        $ann = $test->getAnnotations();
+        $ann = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($test),
+            $test->getName(false)
+        );
 
         return isset($ann['method']['slowThreshold'][0]) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
     }

--- a/src/includes/speed-trap-listener.php
+++ b/src/includes/speed-trap-listener.php
@@ -319,10 +319,10 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      */
     protected function getSlowThreshold(PHPUnit_Framework_TestCase $test)
     {
-		$ann = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-			get_class($test),
-			$test->getName(false)
-		);
+        $ann = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($test),
+            $test->getName(false)
+        );
 
         return isset($ann['method']['slowThreshold'][0]) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
     }

--- a/src/includes/speed-trap-listener.php
+++ b/src/includes/speed-trap-listener.php
@@ -319,10 +319,10 @@ class SpeedTrapListener implements PHPUnit_Framework_TestListener
      */
     protected function getSlowThreshold(PHPUnit_Framework_TestCase $test)
     {
-        $ann = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($test),
-            $test->getName(false)
-        );
+		$ann = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+			get_class($test),
+			$test->getName(false)
+		);
 
         return isset($ann['method']['slowThreshold'][0]) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
     }

--- a/src/includes/testcase.php
+++ b/src/includes/testcase.php
@@ -347,7 +347,10 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	function expectDeprecated() {
-		$annotations = $this->getAnnotations();
+        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->name
+        );
 		foreach ( array( 'class', 'method' ) as $depth ) {
 			if ( ! empty( $annotations[ $depth ]['expectedDeprecated'] ) )
 				$this->expected_deprecated = array_merge( $this->expected_deprecated, $annotations[ $depth ]['expectedDeprecated'] );

--- a/src/includes/testcase.php
+++ b/src/includes/testcase.php
@@ -347,10 +347,10 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	function expectDeprecated() {
-		$annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-			get_class($this),
-			$this->name
-		);
+        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->name
+        );
 		foreach ( array( 'class', 'method' ) as $depth ) {
 			if ( ! empty( $annotations[ $depth ]['expectedDeprecated'] ) )
 				$this->expected_deprecated = array_merge( $this->expected_deprecated, $annotations[ $depth ]['expectedDeprecated'] );

--- a/src/includes/testcase.php
+++ b/src/includes/testcase.php
@@ -347,10 +347,10 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	function expectDeprecated() {
-        $annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->name
-        );
+		$annotations = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+			get_class($this),
+			$this->name
+		);
 		foreach ( array( 'class', 'method' ) as $depth ) {
 			if ( ! empty( $annotations[ $depth ]['expectedDeprecated'] ) )
 				$this->expected_deprecated = array_merge( $this->expected_deprecated, $annotations[ $depth ]['expectedDeprecated'] );

--- a/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
+++ b/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
@@ -63,14 +63,14 @@ trait WithCodeceptionTestCaseEnhancements
         if (
             !class_exists('\PHPUnit\Util\Test') ||
             !method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
-            !method_exists($this, 'getName')
+            !property_exists($this, 'name')
         ) {
             return;
         }
 
         $annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
             get_class($this),
-            $this->getName(false)
+            $this->name
         );
 
         foreach ([ 'class', 'method' ] as $annotationGroup) {

--- a/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
+++ b/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
@@ -60,18 +60,18 @@ trait WithCodeceptionTestCaseEnhancements
      */
     protected function checkSeparateProcessConfiguration()
     {
-        if (
-            !class_exists('\PHPUnit\Util\Test') ||
-            !method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
-            !method_exists($this, 'getName')
-        ) {
-            return;
-        }
+		if (
+			!class_exists('\PHPUnit\Util\Test') ||
+			!method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
+			!method_exists($this, 'getName')
+		) {
+			return;
+		}
 
-        $annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-            get_class($this),
-            $this->getName(false)
-        );
+		$annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+			get_class($this),
+			$this->getName(false)
+		);
 
         foreach ([ 'class', 'method' ] as $annotationGroup) {
             if (! isset($annotationGroups[ $annotationGroup ])) {
@@ -94,8 +94,8 @@ Running WPTestCase tests in a separate processes requires the following annotati
  * @runInSeparateProcess
  * @preserveGlobalState disabled
  */
- 
-Read more at: 
+
+Read more at:
 * https://phpunit.readthedocs.io/en/9.1/annotations.html?highlight=runInSeparateProcess#runinseparateprocess
 * https://wpbrowser.wptestkit.dev/advanced/run-in-separate-process
 

--- a/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
+++ b/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
@@ -60,6 +60,7 @@ trait WithCodeceptionTestCaseEnhancements
      */
     protected function checkSeparateProcessConfiguration()
     {
+        //phpcs:ignore PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace
         if (
             !class_exists('\PHPUnit\Util\Test') ||
             !method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||

--- a/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
+++ b/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
@@ -60,11 +60,18 @@ trait WithCodeceptionTestCaseEnhancements
      */
     protected function checkSeparateProcessConfiguration()
     {
-        if (! method_exists($this, 'getAnnotations')) {
+        if (
+            !class_exists('\PHPUnit\Util\Test') ||
+            !method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
+            !method_exists($this, 'getName')
+        ) {
             return;
         }
 
-        $annotationGroups = $this->getAnnotations();
+        $annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->getName(false)
+        );
 
         foreach ([ 'class', 'method' ] as $annotationGroup) {
             if (! isset($annotationGroups[ $annotationGroup ])) {

--- a/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
+++ b/src/tad/WPBrowser/Traits/WithCodeceptionTestCaseEnhancements.php
@@ -60,18 +60,18 @@ trait WithCodeceptionTestCaseEnhancements
      */
     protected function checkSeparateProcessConfiguration()
     {
-		if (
-			!class_exists('\PHPUnit\Util\Test') ||
-			!method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
-			!method_exists($this, 'getName')
-		) {
-			return;
-		}
+        if (
+            !class_exists('\PHPUnit\Util\Test') ||
+            !method_exists('\PHPUnit\Util\Test', 'parseTestMethodAnnotations') ||
+            !method_exists($this, 'getName')
+        ) {
+            return;
+        }
 
-		$annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
-			get_class($this),
-			$this->getName(false)
-		);
+        $annotationGroups = \PHPUnit\Util\Test::parseTestMethodAnnotations(
+            get_class($this),
+            $this->getName(false)
+        );
 
         foreach ([ 'class', 'method' ] as $annotationGroup) {
             if (! isset($annotationGroups[ $annotationGroup ])) {
@@ -94,8 +94,8 @@ Running WPTestCase tests in a separate processes requires the following annotati
  * @runInSeparateProcess
  * @preserveGlobalState disabled
  */
-
-Read more at:
+ 
+Read more at: 
 * https://phpunit.readthedocs.io/en/9.1/annotations.html?highlight=runInSeparateProcess#runinseparateprocess
 * https://wpbrowser.wptestkit.dev/advanced/run-in-separate-process
 


### PR DESCRIPTION
PHPUnit 9.5.0 [removed](https://github.com/sebastianbergmann/phpunit/commit/68582043e149039cfa3596b42ed35753dcf54fb2#diff-75a3eeca974a0ce169359a31becc86004ea431fb1811f13e1ff04b06fb926aeaL939-L949) the `getAnnotation()` method, thus triggering this error when running wpunit tests:

`[Error] Call to undefined method DisabledCacheNoticeTest::getAnnotations()`

`getAnnotation()` is a wrapper for `\PHPUnit\Util\Test::parseTestMethodAnnotations()`, which is present in [all](https://github.com/sebastianbergmann/phpunit/blame/28dbd82fda9aba0588ef68fb4960d7fabfa27c5f/PHPUnit/Util/Test.php#L374) PHPUnit versions.

This PR replaces all calls of `getAnnotation()` with calls to `\PHPUnit\Util\Test::parseTestMethodAnnotations()` instead.

I have not tested this very thoroughly, but pointing my `composer.json` to use this PR branch makes my test run again.