### PR TITLE
fix: Remove space characters causing yml parse error

### DIFF
--- a/src/Codeception/Template/Wpbrowser.php
+++ b/src/Codeception/Template/Wpbrowser.php
@@ -608,7 +608,7 @@ EOF;
                 $installationData['theme']
                 : "[{$installationData['parentTheme']}, {$installationData['theme']}]";
             $suiteConfig .= <<<EOF
-            
+
             theme: {$theme}
 EOF;
         }
@@ -616,7 +616,7 @@ EOF;
         $plugins     = $installationData['plugins'];
         $plugins     = "'" . implode("', '", (array) $plugins) . "'";
         $suiteConfig .= <<< EOF
-        
+
             plugins: [{$plugins}]
             activatePlugins: [{$plugins}]
 EOF;


### PR DESCRIPTION
For issue:[BUG] init wpbrowser error: Unexpected characters near " " at line 20 (near "title: "Test" ") #474