### PR TITLE
Allow havePlugin and haveMuPlugin without an extension

### DIFF
--- a/src/Codeception/Module/WPFilesystem.php
+++ b/src/Codeception/Module/WPFilesystem.php
@@ -1107,6 +1107,10 @@ class WPFilesystem extends Filesystem
         $path = str_replace('\\', '/', $path);
         $fullPath = $this->config['plugins'] . unleadslashit($path);
 
+        if (!isset(pathinfo($fullPath)['extension'])) {
+            $fullPath .= '.php';
+        }
+
         if (strpos($path, '/') === false) {
             $slug = pathinfo($fullPath, PATHINFO_FILENAME);
             $toClean = $fullPath;
@@ -1172,6 +1176,11 @@ PHP;
     public function haveMuPlugin($filename, $code)
     {
         $fullPath = $this->config['mu-plugins'] . unleadslashit($filename);
+
+        if (!isset(pathinfo($fullPath)['extension'])) {
+            $fullPath .= '.php';
+        }
+
         $dir = dirname($fullPath);
 
         if (!file_exists($dir)) {

--- a/tests/unit/Codeception/Module/WPFilesystemTest.php
+++ b/tests/unit/Codeception/Module/WPFilesystemTest.php
@@ -1137,4 +1137,46 @@ PHP;
         Assert::assertFileDoesNotExist($pluginFile);
         $this->assertFileExists($pluginsFolder);
     }
+
+    public function plugin_path_without_extension()
+    {
+        return [
+            ['input' => 'foo', 'expected' => 'foo.php'],
+            ['input' => 'foo/bar', 'expected' => 'foo/bar.php'],
+            ['input' => 'foo.html', 'expected' => 'foo.html'],
+            ['input' => 'foo/bar.html', 'expected' => 'foo/bar.html'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider plugin_path_without_extension
+     */
+    public function should_allow_passing_plugin_filename_without_extension($input, $expected)
+    {
+        $sut = $this->make_instance();
+
+        $pluginsFolder = $this->config['wpRootFolder'] . $this->config['plugins'];
+        $pluginFile = "$pluginsFolder/$expected";
+
+        $sut->havePlugin($input, '');
+
+        $this->assertFileExists($pluginFile);
+    }
+
+    /**
+     * @test
+     * @dataProvider plugin_path_without_extension
+     */
+    public function should_allow_passing_muplugin_filename_without_extension($input, $expected)
+    {
+        $sut = $this->make_instance();
+
+        $muPluginsFolder = $this->config['wpRootFolder'] . $this->config['mu-plugins'];
+        $muPluginFile = "$muPluginsFolder/$expected";
+
+        $sut->haveMuPlugin($input, '');
+
+        $this->assertFileExists($muPluginFile);
+    }
 }


### PR DESCRIPTION
This PR allows you to use `havePlugin` and `haveMuPlugin` and omit the file extension, which, if empty, will fallback to `.php`.

These are interpreted exactly the same:

```php
$I->havePlugin('doSomething', '');
$I->havePlugin('doSomething.php', '');
```

Which makes it similar to how `haveTheme` behaves, which takes a folder as the first parameter:

```php
$I->haveTheme('someTheme', '', '');
```

I'm writing a lot of webdriver tests lately, this has got me stuck twice this month already. It's easy to forget you need the extension on that parameter.

