### PR TITLE
Symlinker: Change is_file to file_exists to support directories

### DIFF
--- a/src/tad/WPBrowser/Extension/Symlinker.php
+++ b/src/tad/WPBrowser/Extension/Symlinker.php
@@ -64,7 +64,7 @@ class Symlinker extends Extension
         $destination = $this->getDestination($rootFolder, $eventSettings);
 
         try {
-            if (!is_file($destination)) {
+            if (!file_exists($destination)) {
                 if (!symlink($rootFolder, $destination)) {
                     throw new ExtensionException(
                         $this,


### PR DESCRIPTION
We've experienced a bug when trying to symlink an entire plugin directory. Specifically, the plugin directory will get symlinked when the tests begin. Symlinker tries to link it again before every test suite.

There's a catch in Symlinker to look for the file existing before linking - `is_file`. But that catch doesn't account for linking an entire directory. 

This PR changes that check to use `file_exists` instead. `file_exists` will check for files, directories, and links. So on subsequent attempts to link the directory, it'll quietly skip the process.

The relevant codeception.yml config is

```yaml
extensions:
    enabled:
        - tad\WPBrowser\Extension\Symlinker
    config:
        tad\WPBrowser\Extension\Symlinker:
            mode: "plugin"
            destination: "/var/www/html/wp-content/plugins"
            rootFolder: "/usr/local/src/config/plugins/plugin_to_test"
```

Output

```shell
root@b54812db216a:/var/www/html# codecept run
Codeception PHP Testing Framework v4.1.17
Powered by PHPUnit 9.5.2 by Sebastian Bergmann and contributors.
[Seed] 105795379
Symbolically linked plugin folder [/var/www/html/wp-content/plugins/wpengine-editorial-flow]

Acceptance Tests (0) -------------------

In ErrorHandler.php line 83:

  symlink(): File exists at ../../../root/.config/composer/vendor/lucatume/wp-browser/src/tad/WPBrowser/Extension/Symlinker.php:68

```