### PR TITLE
fix(includes/functions.php) hydrate actions

### DIFF
--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -177,20 +177,13 @@ function _upload_dir_https($uploads)
 }
 
 if (! function_exists('wp_set_auth_cookie') && ! function_exists('wp_clear_auth_cookie')) {
-    // Skip `setcookie` calls in auth_cookie functions due to warning:
-    // Cannot modify header information - headers already sent by ...
+    // No `setcookie` calls to avoid: "Cannot modify header information - headers already sent"
     function wp_set_auth_cookie($user_id, $remember = false, $secure = '', $token = '')
     {
-        $auth_cookie = null;
-        $expire = null;
-        $expiration = null;
-        $user_id = null;
-        $scheme = null;
         /** This action is documented in wp-inclues/pluggable.php */
-        do_action('set_auth_cookie', $auth_cookie, $expire, $expiration, $user_id, $scheme);
-        $logged_in_cookie = null;
+        do_action('set_auth_cookie', null, null, null, $user_id, null);
         /** This action is documented in wp-inclues/pluggable.php */
-        do_action('set_logged_in_cookie', $logged_in_cookie, $expire, $expiration, $user_id, 'logged_in');
+        do_action('set_logged_in_cookie', null, null, null, $user_id, 'logged_in');
     }
 
     function wp_clear_auth_cookie()


### PR DESCRIPTION
This should fix the issue reported in #509 where the two actions fired in the plugged `wp_set_auth_cookie` function are not provided the relevant parameters they could use to further customize the behavior.