### PR TITLE
Depend on stable version of phpass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,6 @@
   ],
   "minimum-stability": "dev",
   "prefer-stable" : true,
-  "repositories": [
-    { "name": "bordoni/phpass",
-      "type": "github",
-      "url": "https://github.com/bordoni/phpass",
-      "no-api": true
-    }
-  ],
   "require": {
     "php": ">=5.6.0",
     "ext-pdo": "*",
@@ -35,7 +28,7 @@
     "codeception/codeception": "^2.5 || ^3.0 || ^4.0",
     "dg/mysql-dump": "^1.3",
     "mikehaertl/php-shellcommand": "^1.6",
-    "bordoni/phpass": "dev-main",
+    "bordoni/phpass": "^0.3",
     "mikemclin/laravel-wp-password": "~2.0.0",
     "wp-cli/wp-cli": ">=2.0 <3.0.0",
     "zordius/lightncandy": "^1.2",


### PR DESCRIPTION
This PR is related to https://github.com/lucatume/wp-browser/pull/524#issuecomment-918106395

#524  forced to have `"minimum-stability": "dev"` to use wp-browser, as at the time there were no stable version of that package available.

This PR uses the stable version that's now available on Packagist, so that `minimum-stability: dev` should no longer be necessary to use wp-browser.