### PR TITLE
Escape PHP path to prevent crash when it contains a space

### DIFF
--- a/src/tad/WPBrowser/Traits/WithWpCli.php
+++ b/src/tad/WPBrowser/Traits/WithWpCli.php
@@ -264,8 +264,6 @@ trait WithWpCli
             $fullCommand[0] = escapeshellarg($fullCommand[0]);
         }
 
-        codecept_debug($fullCommand);
-
         return $fullCommand;
     }
 

--- a/src/tad/WPBrowser/Traits/WithWpCli.php
+++ b/src/tad/WPBrowser/Traits/WithWpCli.php
@@ -259,6 +259,13 @@ trait WithWpCli
             PHP_BINARY,
             $this->getWpCliBootFilePath(),
         ], (array)$command);
+
+        if (!empty($fullCommand) && count($fullCommand) > 0) {
+            $fullCommand[0] = escapeshellarg($fullCommand[0]);
+        }
+
+        codecept_debug($fullCommand);
+
         return $fullCommand;
     }
 


### PR DESCRIPTION
Fixes #516