### PR TITLE
Use `intl` module transliteration function if available

### DIFF
--- a/src/tad/WPBrowser/string.php
+++ b/src/tad/WPBrowser/string.php
@@ -54,7 +54,11 @@ function slug($string, $sep = '-', $let = false)
     }
 
     // Transliterate.
-    $step3 = iconv('utf-8', 'us-ascii//TRANSLIT', $step2);
+    if ( function_exists( 'transliterator_transliterate' ) ) {
+        $step3 = transliterator_transliterate( 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $step2 );
+    } else {
+        $step3 = iconv('utf-8', 'us-ascii//TRANSLIT', $step2);
+    }
 
     if ($step3 === false) {
         throw new \InvalidArgumentException('Failed to slugify string');

--- a/src/tad/WPBrowser/string.php
+++ b/src/tad/WPBrowser/string.php
@@ -54,8 +54,8 @@ function slug($string, $sep = '-', $let = false)
     }
 
     // Transliterate.
-    if ( function_exists( 'transliterator_transliterate' ) ) {
-        $step3 = transliterator_transliterate( 'Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $step2 );
+    if (function_exists('transliterator_transliterate')) {
+        $step3 = transliterator_transliterate('Any-Latin; Latin-ASCII; [\u0080-\u7fff] remove', $step2);
     } else {
         $step3 = iconv('utf-8', 'us-ascii//TRANSLIT', $step2);
     }


### PR DESCRIPTION
On some systems like Alpine Linux the libiconv library used by the `iconv()` function doesn't work properly. This update will make use of the transliteration functions provided by the `intl` PHP module if available.

Related to #542