### PR TITLE
Fix the case when `env` file can be with LF line separators on Windows.

### DIFF
--- a/src/tad/WPBrowser/env.php
+++ b/src/tad/WPBrowser/env.php
@@ -33,12 +33,12 @@ function envFile($file)
         throw new \InvalidArgumentException('Could not read ' . $file . ' contents.');
     }
 
-	$envFileContents = str_replace( "\r\n", "\n", $envFileContents );
+    $envFileContents = str_replace( "\r\n", "\n", $envFileContents );
 
     $pattern = '/^(?<key>.*?)=("(?<q_value>.*)(?<!\\\\)"|(?<value>.*?))([\\s]*#.*)*$/ui';
 
     $vars = array_reduce(
-	    array_filter(explode("\n", $envFileContents)),
+        array_filter(explode("\n", $envFileContents)),
         static function (array $lines, $line) use ($pattern) {
             if (strpos($line, '#') === 0) {
                 return $lines;

--- a/src/tad/WPBrowser/env.php
+++ b/src/tad/WPBrowser/env.php
@@ -33,10 +33,12 @@ function envFile($file)
         throw new \InvalidArgumentException('Could not read ' . $file . ' contents.');
     }
 
+	$envFileContents = str_replace( "\r\n", "\n", $envFileContents );
+
     $pattern = '/^(?<key>.*?)=("(?<q_value>.*)(?<!\\\\)"|(?<value>.*?))([\\s]*#.*)*$/ui';
 
     $vars = array_reduce(
-        array_filter(explode(PHP_EOL, $envFileContents)),
+	    array_filter(explode("\n", $envFileContents)),
         static function (array $lines, $line) use ($pattern) {
             if (strpos($line, '#') === 0) {
                 return $lines;


### PR DESCRIPTION
On Windows, it is wise to create all files with LF separators, avoiding potential problems on deployment to Linux servers.

Env file created on Windows with LF line separators is not parsed now and Codeception tests fail. This PR proposes a simple fix.