### PR TITLE
Introduce an argument to skip defining the pluggable functions

### DIFF
--- a/docs/modules/WPLoader.md
+++ b/docs/modules/WPLoader.md
@@ -22,6 +22,7 @@ When configured to only load WordPress (`loadOnly: true`) then any database oper
 * `installationTableHandling` - defaults to `empty`; it controls how tables created by WordPress and plugins will be handled during the installation of WordPress during tests. By default tables will be emptied of any content, but some plugins might require tables to be dropped before WordPress is installed and after plugins are activated (this used to be the default behavior). Supported values are `drop` to drop the tables, `empty` to just empty the tables and `let` to do nothing about the tables. If you get errors from database queries while the `WPLoader` module installs the tests, then try changing this parameter value. 
 * `wpDebug` - defaults to `true`, the value the `WP_DEBUG` constant will be set to.
 * `multisite` - defaults to `false`, the value the `MULTISITE` constant will be set to.
+* `skipPluggables` - defaults to `false`, if set to `true` will skip the definition of pluggable functions.
 * `dbCharset` - defaults to `utf8`, the value the `DB_CHARSET` constant will be set to.
 * `dbCollate` - defaults to an empty string, the value the `DB_COLLATE` constant will be set to.
 * `tablePrefix` - defaults to `wptests_`, the value the `$table_prefix` variable will be set to.

--- a/src/Codeception/Module/WPLoader.php
+++ b/src/Codeception/Module/WPLoader.php
@@ -140,6 +140,8 @@ class WPLoader extends Module
      * `folder/plugin-file.php` format.
      * bootstrapActions - array, def. `[]`, a list of actions that should be
      * called after before any test case runs.
+     * skipPluggables - bool, def. `false`, if set to `true` will skip the
+     * definition of pluggable functions.
      *
      *
      * @var array<string,mixed>|Configuration
@@ -151,6 +153,7 @@ class WPLoader extends Module
             'installationTableHandling' => 'empty',
             'wpDebug'                   => true,
             'multisite'                 => false,
+            'skipPluggables'            => false,
             'dbCharset'                 => 'utf8',
             'dbCollate'                 => '',
             'tablePrefix'               => 'wptests_',
@@ -464,6 +467,10 @@ class WPLoader extends Module
         }
 
         require_once dirname(dirname(__DIR__)) . '/includes/functions.php';
+
+        if (! $this->config['skipPluggables']) {
+            require_once dirname(dirname(__DIR__)) . '/includes/pluggable-functions.php';
+        }
 
         if (! empty($this->config['loadOnly'])) {
             $this->bootstrapWP();

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -196,20 +196,3 @@ function _upload_dir_https($uploads)
 
     return $uploads;
 }
-
-if (! function_exists('wp_set_auth_cookie') && ! function_exists('wp_clear_auth_cookie')) {
-    // No `setcookie` calls to avoid: "Cannot modify header information - headers already sent"
-    function wp_set_auth_cookie($user_id, $remember = false, $secure = '', $token = '')
-    {
-        /** This action is documented in wp-inclues/pluggable.php */
-        do_action('set_auth_cookie', null, null, null, $user_id, null);
-        /** This action is documented in wp-inclues/pluggable.php */
-        do_action('set_logged_in_cookie', null, null, null, $user_id, 'logged_in');
-    }
-
-    function wp_clear_auth_cookie()
-    {
-        /** This action is documented in wp-inclues/pluggable.php */
-        do_action('clear_auth_cookie');
-    }
-}

--- a/src/includes/pluggable-functions.php
+++ b/src/includes/pluggable-functions.php
@@ -1,0 +1,18 @@
+<?php
+
+if (! function_exists('wp_set_auth_cookie') && ! function_exists('wp_clear_auth_cookie')) {
+    // No `setcookie` calls to avoid: "Cannot modify header information - headers already sent"
+    function wp_set_auth_cookie($user_id, $remember = false, $secure = '', $token = '')
+    {
+        /** This action is documented in wp-inclues/pluggable.php */
+        do_action('set_auth_cookie', null, null, null, $user_id, null);
+        /** This action is documented in wp-inclues/pluggable.php */
+        do_action('set_logged_in_cookie', null, null, null, $user_id, 'logged_in');
+    }
+
+    function wp_clear_auth_cookie()
+    {
+        /** This action is documented in wp-inclues/pluggable.php */
+        do_action('clear_auth_cookie');
+    }
+}


### PR DESCRIPTION
[The tests for my User Switching plugin](https://github.com/johnbillion/user-switching/runs/4707473777?check_suite_focus=true) rely on valid parameters being passed to the `set_auth_cookie` action. In WPBrowser the `wp_set_auth_cookie()` and `wp_clear_auth_cookie()` functions are no-oped which means even though they still call the relevant actions, the data they pass to them isn't correct, and other behaviour inside these functions such as creating and clearing user sessions doesn't happen. This causes my tests to fail.

I would like to run the tests without WPBrowser no-oping these functions. A new config option that controls whether or not these functions are overridden would allow me to do this. With this option in place, the functions aren't overridden, there's no unexpected output or errors due to headers already sent, and the tests pass.

I've used `skipPluggables` as the config option name but this is pretty terrible and not very descriptive. Naming suggestions welcome.