### PR TITLE
Switch off mysqli reporting mode so the core installer successfully runs on PHP 8.1

### DIFF
--- a/src/includes/isolated-install.php
+++ b/src/includes/isolated-install.php
@@ -6,6 +6,11 @@
 
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
+// https://core.trac.wordpress.org/ticket/52825
+if (function_exists('mysqli_report')) {
+	mysqli_report(MYSQLI_REPORT_OFF);
+}
+
 $configuration = unserialize(base64_decode($argv[1]));
 
 $multisite = !empty($argv[2]) ? $argv[2] : false;


### PR DESCRIPTION
Background: https://core.trac.wordpress.org/ticket/52825

In PHP 8.1 the default mode for mysqli reporting was changed so that errors throw an exception. This breaks the WordPress core installer on PHP 8.1 which now throws an exception due to it checking the existence of the `wp_options` table but not `try`ing it. The issue will be "fixed" in WordPress 5.9.

This also means that integration tests in WPBrowser don't currently work with PHP 8.1 with any WordPress version prior to 5.9 because the exception thrown during core installation won't be caught. [I had some fun figuring this out](https://github.com/johnbillion/extended-cpts/actions).

We can fix the issue in WPBrowser by switching off mysqli reporting mode so exceptions aren't thrown. This allows the core installer to run successfully.

There are several deprecation notices coming from WPBrowser files in PHP 8.1 but nothing that stops it working, at least for integration tests.