### PR TITLE
Pass the configured table prefix to the user capability builder

### DIFF
--- a/src/Codeception/Module/WPDb.php
+++ b/src/Codeception/Module/WPDb.php
@@ -2538,7 +2538,7 @@ class WPDb extends Db
      */
     public function haveUserCapabilitiesInDatabase($userId, $role)
     {
-        $insert = User::buildCapabilities($role);
+        $insert = User::buildCapabilities($role, $this->grabTablePrefix());
 
         $roleIds = [];
         foreach ($insert as $meta_key => $meta_value) {
@@ -2625,7 +2625,7 @@ class WPDb extends Db
      */
     public function haveUserLevelsInDatabase($userId, $role)
     {
-        $roles = User::buildCapabilities($role);
+        $roles = User::buildCapabilities($role, $this->grabTablePrefix());
 
         $ids = [];
         foreach ($roles as $roleMetaKey => $roleMetaValue) {


### PR DESCRIPTION
When using a custom `tablePrefix` for `WPDb`, the prefix isn't passed to the user capability builder. This means when a user is inserted it uses `wp_capabilities` for the user meta key, which is incorrect. The result is that the user ends up with no role and no capabilities.

**To reproduce:**

* Set up an acceptance test suite that also uses `WPDb` configured with `tablePrefix: wp_foo_`
* Create a test step such as the following:  

  ```php
  $user_id = $I->haveUserInDatabase( 'editor', 'editor' );
  $I->seeUserMetaInDatabase( [
      'user_id' => $user_id,
      'meta_key' => 'wp_foo_capabilities',
  ] );
  ```

* Confirm the assertion fails

---

This PR fixes the issue by passing the configured table prefix to the user capability builder methods.