### PR TITLE
Trigger an error when plugins in `activePlugins` cannot be included or activated

### DIFF
--- a/src/includes/bootstrap.php
+++ b/src/includes/bootstrap.php
@@ -136,13 +136,17 @@ if(empty($skipWordPressInstall)){
 		codecept_debug('Installing WordPress in isolated process...');
 		ob_start();
 		$isolatedInstallationScript = __DIR__ . '/isolated-install.php';
-		system(implode(' ', [
+		$resultLine = system(implode(' ', [
 			WP_PHP_BINARY,
 			escapeshellarg($isolatedInstallationScript),
 			escapeshellarg(base64_encode(serialize($environment))),
 			$multisite,
-		]));
+		]), $resultCode);
 		codecept_debug("Isolated installation script output: \n\n" . ob_get_clean());
+
+		if ($resultCode !== 0) {
+			throw new \Exception($resultLine);
+		}
 	}
 }
 

--- a/src/includes/isolated-install.php
+++ b/src/includes/isolated-install.php
@@ -105,7 +105,7 @@ foreach ($activePlugins as $activePlugin) {
 	if (!file_exists($path)) {
 		$path = dirname($configuration['root']) . '/' . $activePlugin;
 	}
-	include_once $path;
+	require_once $path;
 }
 
 $wpdb->query("SET FOREIGN_KEY_CHECKS = 0");
@@ -201,6 +201,11 @@ if (!empty($activePlugins)) {
 
 	foreach ($activePlugins as $plugin) {
 		printf("\n%sctivating plugin [%s]...", $multisite ? 'Network a' : 'A', $plugin);
-		activate_plugin($plugin, null, $multisite, false);
+		$activated = activate_plugin($plugin, null, $multisite, false);
+
+		if (is_wp_error($activated)) {
+			echo $activated->get_error_message();
+			exit(1);
+		}
 	}
 }

--- a/src/includes/isolated-install.php
+++ b/src/includes/isolated-install.php
@@ -5,6 +5,8 @@
  */
 
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
+ini_set('display_errors', '1');
+
 
 // https://core.trac.wordpress.org/ticket/52825
 if (function_exists('mysqli_report')) {
@@ -69,6 +71,9 @@ $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 
 require_once ABSPATH . '/wp-settings.php';
+
+// Re-enable error output in case it was disabled during wp-settings.php bootstrap
+ini_set('display_errors', '1');
 
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 require_once ABSPATH . '/wp-includes/wp-db.php';


### PR DESCRIPTION
If an invalid plugin is included in the `activePlugins` config for `WPLoader` it fails silently and the tests still run. It's then up to the developer to spend time investigating why the test suite runs but all the tests fail.

Instead, any problems including or activating plugins during installation should be thrown as an exception so the main command fails.

**Changes:**

* Ensure errors are shown in isolated-install.php (need to enable it once at the top and then once again after `wp-settings.php` is included)
* Trigger an error if the plugin file doesn't exist or the plugin cannot be activated
* Surface the error from `system()` in `bootstrap.php` and throw an exception which will be caught by Codeception and displayed appropriately

**Steps to test:**

* Create an integration test suite that uses `WPLoader`
* Include an `activePlugins` config with an invalid file path
* Run your test suite

Before this change the tests would still run but they all fail. After this change, the user is shown an fatal error message from Codeception:

```
Fatal error: require_once(): Failed opening required 'wp-content/plugins/i-dont-exist/i-dont-exist.php' (include_path='.:/usr/local/lib/php') in vendor/lucatume/wp-browser/src/includes/isolated-install.php on line 107
```