### PR TITLE
Fix issue #557, related to driver not defined

### DIFF
--- a/src/Codeception/Module/WPDb.php
+++ b/src/Codeception/Module/WPDb.php
@@ -257,7 +257,7 @@ class WPDb extends Db
                 throw new \InvalidArgumentException("Dump file [{$dumpFile}] does not exist or is not readable.");
             }
 
-            $this->driver->load($dumpFile);
+            $this->_getDriver()->load(file($dumpFile));
 
             return;
         }


### PR DESCRIPTION
Fix the issue lucatume/wp-browser/issues/557 where the property `$driver` is not defined and the file content is not passed to the load function.