### PR TITLE
Update code example version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the following requirements in your `composer.json` file, in the `require-dev
 ```json
 {
   "require-dev": {
-    "lucatume/wp-browser": "^2.4",
+    "lucatume/wp-browser": "^3.0",
     "codeception/module-asserts": "^1.0",
     "codeception/module-phpbrowser": "^1.0",
     "codeception/module-webdriver": "^1.0",


### PR DESCRIPTION
Someone might copy and paste this example and use an outdated version of wp-browser.

This PR updates the code example to use the latest wp-browser, with a version constraint that you won't have to change so soon.

PS: It's been a while since Codeception 4.0 came out. Maybe it's time to add these instructions as default, instead of 4.0-specific? If so, I can look into it if you wish.