### PR TITLE
add return type to WPTestCase::factory() for static analysis compat

### DIFF
--- a/src/Codeception/TestCase/WPTestCase.php
+++ b/src/Codeception/TestCase/WPTestCase.php
@@ -145,7 +145,10 @@ class WPTestCase extends \tad\WPBrowser\Compat\Codeception\Unit
         global $wpdb;
         $wpdb->query('COMMIT;');
     }
-
+    
+    /**
+     * @return WP_UnitTest_Factory
+     */
     protected static function factory()
     {
         static $factory = null;


### PR DESCRIPTION
This is something that psalm complains nonstop about in all test cases. It got so annoying the add ignore annotations that I opened this PR. 