### PR TITLE
Add a method for visiting the user editing screen

### DIFF
--- a/src/Codeception/Module/WPBrowserMethods.php
+++ b/src/Codeception/Module/WPBrowserMethods.php
@@ -478,6 +478,32 @@ trait WPBrowserMethods
     }
 
     /**
+     * Go to the admin page to edit the user with the specified ID.
+     *
+     * The method will **not** handle authentication the admin area.
+     *
+     * @example
+     * ```php
+     * $I->loginAsAdmin();
+     * $userId = $I->haveUserInDatabase('luca', 'editor');
+     * $I->amEditingUserWithId($userId);
+     * $I->fillField('email', 'new@example.net');
+     * ```
+     *
+     * @param int $id The user ID.
+     *
+     * @return void
+     */
+    public function amEditingUserWithId($id)
+    {
+        if (!is_numeric($id) || (int)$id !== $id) {
+            throw new \InvalidArgumentException('ID must be an int value');
+        }
+
+        $this->amOnAdminPage('/user-edit.php?user_id=' . $id);
+    }
+
+    /**
      * Configures for back-compatibility.
      *
      * @return void

--- a/tests/wpmodule/UserOperationsCest.php
+++ b/tests/wpmodule/UserOperationsCest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Class UserOperationsCest
+ */
+class UserOperationsCest
+{
+
+    /**
+     * @test
+     * it should require to login when trying to access user edit page and not logged in
+     */
+    public function it_should_require_to_login_when_trying_to_access_user_edit_page_and_not_logged_in(WpmoduleTester $I)
+    {
+        $id = $I->haveUserInDatabase('editor');
+
+        $I->amEditingUserWithId($id);
+
+        $I->seeElement('body.login');
+    }
+
+    /**
+     * @test
+     * it should allow accessing a user edit page
+     */
+    public function it_should_allow_accessing_a_user_edit_page(WpmoduleTester $I)
+    {
+        $id = $I->haveUserInDatabase('editor');
+
+        $I->loginAsAdmin();
+        $I->amEditingUserWithId($id);
+
+        $I->seeElement('body.wp-admin.user-edit-php');
+    }
+}


### PR DESCRIPTION
This introduces an `amEditingUserWithId()` method which works similarly to the existing `amEditingPostWithId()` method.

I've not included the changes to the `tests/_support/_generated` directory in this PR.

How can I regenerate the documentation markdown files so this method gets included?