### PR TITLE
Fix wpdb file deprecated notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- If possible, load the `wpdb` class from the `wp-includes/class-wpdb.php` file on newer versions of WordPress.
+
 ## [3.1.8] 2023-02-24;
 
 ### Changed

--- a/src/includes/isolated-install.php
+++ b/src/includes/isolated-install.php
@@ -76,7 +76,11 @@ require_once ABSPATH . '/wp-settings.php';
 ini_set('display_errors', '1');
 
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';
-require_once ABSPATH . '/wp-includes/wp-db.php';
+if (file_exists(ABSPATH . '/wp-includes/class-wpdb.php')) {
+    require_once ABSPATH . '/wp-includes/class-wpdb.php';
+} else {
+    require_once ABSPATH . '/wp-includes/wp-db.php';
+}
 
 // Override the PHPMailer
 global $phpmailer;

--- a/src/includes/same-scope-install.php
+++ b/src/includes/same-scope-install.php
@@ -17,7 +17,11 @@ $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 require_once ABSPATH . '/wp-settings.php';
 
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';
-require_once ABSPATH . '/wp-includes/wp-db.php';
+if (file_exists(ABSPATH . '/wp-includes/class-wpdb.php')) {
+    require_once ABSPATH . '/wp-includes/class-wpdb.php';
+} else {
+    require_once ABSPATH . '/wp-includes/wp-db.php';
+}
 
 // Override the PHPMailer
 global $phpmailer;


### PR DESCRIPTION
Fixes #610 by loading `wpdb` from the `wp-includes/class-wpdb.php` file, if present.
