### PR TITLE
Allow longer database names

### DIFF
--- a/src/WordPress/Database/MysqlDatabase.php
+++ b/src/WordPress/Database/MysqlDatabase.php
@@ -30,7 +30,7 @@ class MysqlDatabase implements DatabaseInterface
         private string $dbHost,
         private string $tablePrefix = 'wp_'
     ) {
-        if (!preg_match('/^[a-zA-Z][\w_]{0,23}$/', $dbName) || str_starts_with('ii', $dbName)) {
+        if (!preg_match('/^[a-zA-Z][\w_]{0,64}$/', $dbName) || str_starts_with('ii', $dbName)) {
             throw new DbException(
                 "Invalid database name: $dbName",
                 DbException::INVALID_DB_NAME


### PR DESCRIPTION
I was experiencing the same issue as #648

```
In WPLoader.php line 347:

  lucatume\WPBrowser\Module\WPLoader module is not configured!

  Invalid database name: bh_wp_simple_calendar_integration
```

The [MySQL 5.7 documentation](https://dev.mysql.com/doc/refman/5.7/en/identifier-length.html) says 64 characters is valid for database names.
