### PR TITLE
On error, print stdout when stderr is empty

### DIFF
--- a/src/WordPress/WPConfigFile.php
+++ b/src/WordPress/WPConfigFile.php
@@ -126,7 +126,11 @@ class WPConfigFile
 
             if ($result->getExitCode() !== 0) {
                 $previous = $returnValue instanceof Throwable ? $returnValue : null;
-                throw new ProcessException($result->getStderrBuffer(), $result->getExitCode(), $previous);
+                throw new ProcessException(
+					$result->getStderrBuffer() ?: $result->getStdoutBuffer(),
+					$result->getExitCode(),
+					$previous
+                );
             }
 
             $values = $returnValue;

--- a/src/WordPress/WPConfigFile.php
+++ b/src/WordPress/WPConfigFile.php
@@ -127,9 +127,9 @@ class WPConfigFile
             if ($result->getExitCode() !== 0) {
                 $previous = $returnValue instanceof Throwable ? $returnValue : null;
                 throw new ProcessException(
-					$result->getStderrBuffer() ?: $result->getStdoutBuffer(),
-					$result->getExitCode(),
-					$previous
+                    $result->getStderrBuffer() ?: $result->getStdoutBuffer(),
+                    $result->getExitCode(),
+                    $previous
                 );
             }
 


### PR DESCRIPTION
An error was giving me:

```
In WPConfigFile.php line 143:
                                           
  Could not parse the wp-config.php file:  
                                           

In WPConfigFile.php line 129:
                                                       
  [lucatume\WPBrowser\Process\ProcessException (255)]  
```

For whatever reason, `$result->getStderrBuffer()` was empty and the error message was available in `$result->getStdoutBuffer()`.

With this change, the error message is printed:

```
In WPConfigFile.php line 148:
                                                                                                                                                                                                            
  Could not parse the wp-config.php file:                                                                                                                                                                   
  Fatal error: Trait "lucatume\WPBrowser\WordPress\Traits\WordPressChecks" not found in /Users/brianhenry/Sites/bh-wp-simple-calendar/vendor/lucatume/wp-browser/src/WordPress/WPConfigFile.php on line 12  
                                                                                                                                                                                                            

In WPConfigFile.php line 129:
                                                                                                                                                                                                            
  Fatal error: Trait "lucatume\WPBrowser\WordPress\Traits\WordPressChecks" not found in /Users/brianhenry/Sites/bh-wp-simple-calendar/vendor/lucatume/wp-browser/src/WordPress/WPConfigFile.php on line 12                                                                                                                                                                                                         ```