### PR TITLE
Don't fail PR phpcs check where fixes can be automated

### DIFF
--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -9,6 +9,8 @@ jobs:
   php-codesniffer:
     name: "PHPCBF automatically fix violations"
     runs-on: "ubuntu-22.04"
+    permissions:
+      contents: write
     steps:
       -
         name: "Set up PHP"

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -35,6 +35,6 @@ jobs:
         run: "composer run cs-fix"
       -
         name: Commit PHPCBF changes
-        uses: stefanzweifel/git-auto-commit-action@v4.1.1
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "🤖 PHPCBF"

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -30,7 +30,7 @@ jobs:
       -
         name: "Run PHPCBF"
         continue-on-error: true
-        run: "composer cs-fix"
+        run: "composer run cs-fix"
       -
         name: Commit PHPCBF changes
         uses: stefanzweifel/git-auto-commit-action@v4.1.1

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -1,0 +1,38 @@
+name: "PHPCBF automatically fix violations"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  php-codesniffer:
+    name: "PHPCBF automatically fix violations"
+    runs-on: "ubuntu-22.04"
+    steps:
+      -
+        name: "Set up PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "8.0"
+          coverage: "none"
+      -
+        name: "Checkout repository"
+        uses: "actions/checkout@v3"
+      -
+        name: "Validate Composer configuration"
+        run: "composer validate --no-interaction --strict"
+      -
+        name: "Install dependencies"
+        uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "highest"
+      -
+        name: "Run PHPCBF"
+        continue-on-error: true
+        run: "composer cs-fix"
+      -
+        name: Commit PHPCBF changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.1
+        with:
+          commit_message: "🤖 PHPCBF"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -49,5 +49,9 @@ jobs:
             name: "Run PHPHStan"
             run: "composer run stan"
         -
+            name: "Run PHPCBF"
+            continue-on-error: true
+            run: "composer cs-fix"
+        -
             name: "Run PHP Code Sniffer"
             run: "composer run cs"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         -
             name: "Run PHPCBF"
             continue-on-error: true
-            run: "composer cs-fix"
+            run: "composer run cs-fix"
         -
             name: "Run PHP Code Sniffer"
             run: "composer run cs"


### PR DESCRIPTION
* Runs `composer run cs-fix` (phpcbf) before `composer run cs` (phpcs) to automatically fix the errors it can – changes here are not committed
* Adds a workflow that runs on commits to master to run `phpcbf` and commit the changes

I opened a PR earlier which I wrote in the GitHub text editor and the spacing was wrong. It seems unnecessary to have to pull to my machine and run phpcbf where that error can be automatically fixed when merging to master anyway.