### PR TITLE
Add default composer autoload file to `Control::getDefault()`

### DIFF
--- a/src/Process/Protocol/Control.php
+++ b/src/Process/Protocol/Control.php
@@ -78,16 +78,21 @@ class Control
      */
     public static function getDefault(): array
     {
+        if (empty($GLOBALS['_composer_autoload_path'])) {
+            $composerAutoloadPath = is_readable(getcwd() . '/vendor/autoload.php') ?
+                getcwd() . '/vendor/autoload.php'
+                : null;
+        } else {
+            $composerAutoloadPath = $GLOBALS['_composer_autoload_path'];
+        }
+
         return [
             'autoloadFile' => $GLOBALS['_composer_autoload_path'] ?? null,
             'requireFiles' => [],
             'cwd' => getcwd() ?: codecept_root_dir(),
             'codeceptionRootDir' => codecept_root_dir(),
             'codeceptionConfig' => Configuration::isEmpty() ? [] : Configuration::config(),
-            'composerAutoloadPath' => $GLOBALS['_composer_autoload_path']
-                                      ?? is_readable(getcwd() . '/vendor/autoload.php')
-                                            ? getcwd() . '/vendor/autoload.php'
-                                            : null,
+            'composerAutoloadPath' => $composerAutoloadPath,
             'composerBinDir' => $GLOBALS['_composer_bin_dir'] ?? null,
             'env' => $_ENV,
         ];

--- a/src/Process/Protocol/Control.php
+++ b/src/Process/Protocol/Control.php
@@ -84,7 +84,10 @@ class Control
             'cwd' => getcwd() ?: codecept_root_dir(),
             'codeceptionRootDir' => codecept_root_dir(),
             'codeceptionConfig' => Configuration::isEmpty() ? [] : Configuration::config(),
-            'composerAutoloadPath' => $GLOBALS['_composer_autoload_path'] ?? getcwd() . '/vendor/autoload.php',
+            'composerAutoloadPath' => $GLOBALS['_composer_autoload_path']
+                                      ?? is_readable(getcwd() . '/vendor/autoload.php')
+                                            ? getcwd() . '/vendor/autoload.php'
+                                            : null,
             'composerBinDir' => $GLOBALS['_composer_bin_dir'] ?? null,
             'env' => $_ENV,
         ];

--- a/src/Process/Protocol/Control.php
+++ b/src/Process/Protocol/Control.php
@@ -84,7 +84,7 @@ class Control
             'cwd' => getcwd() ?: codecept_root_dir(),
             'codeceptionRootDir' => codecept_root_dir(),
             'codeceptionConfig' => Configuration::isEmpty() ? [] : Configuration::config(),
-            'composerAutoloadPath' => $GLOBALS['_composer_autoload_path'] ?? null,
+            'composerAutoloadPath' => $GLOBALS['_composer_autoload_path'] ?? getcwd() . '/vendor/autoload.php',
             'composerBinDir' => $GLOBALS['_composer_bin_dir'] ?? null,
             'env' => $_ENV,
         ];


### PR DESCRIPTION
To fix:
```
Fatal error: Trait "lucatume\WPBrowser\WordPress\Traits\WordPressChecks" not found in /Users/brianhenry/Sites/bh-wp-simple-calendar/vendor/lucatume/wp-browser/src/WordPress/WPConfigFile.php on line 12  
```

Fixes #656 