### PR TITLE
v35 wptestcase rector

### DIFF
--- a/src/Process/Loop.php
+++ b/src/Process/Loop.php
@@ -130,7 +130,9 @@ class Loop
             }
         }
 
-        array_push($this->workers, ...$builtWorkers);
+        if (count($builtWorkers)) {
+            array_push($this->workers, ...$builtWorkers);
+        }
         $this->sortWorkersByResource();
 
         return $this;

--- a/src/Process/Worker/worker-script.php
+++ b/src/Process/Worker/worker-script.php
@@ -4,11 +4,10 @@ use lucatume\WPBrowser\Process\Protocol\Request;
 use lucatume\WPBrowser\Process\Protocol\Response;
 use lucatume\WPBrowser\Process\SerializableThrowable;
 
-$processSrcRoot = __DIR__ . '/..';
-require_once $processSrcRoot . '/Protocol/Parser.php';
-require_once $processSrcRoot . '/Protocol/Control.php';
-require_once $processSrcRoot . '/Protocol/Request.php';
-require_once $processSrcRoot . '/Protocol/ProtocolException.php';
+require_once __DIR__ . '/../Protocol/Parser.php';
+require_once __DIR__ . '/../Protocol/Control.php';
+require_once __DIR__ . '/../Protocol/Request.php';
+require_once __DIR__ . '/../Protocol/ProtocolException.php';
 
 try {
     if (!isset($argv[1])) {
@@ -22,8 +21,9 @@ try {
     }
 
     $request = Request::fromPayload($payload);
-    $serializableClosure = $request->getSerializableClosure();
-    $returnValue = $serializableClosure();
+    $_wpBrowserWorkerClosure = $request->getSerializableClosure();
+    unset($payload, $request);
+    $returnValue = $_wpBrowserWorkerClosure();
 } catch (Throwable $throwable) {
     $returnValue = new SerializableThrowable($throwable);
 }

--- a/src/TestCase/WPTestCase.php
+++ b/src/TestCase/WPTestCase.php
@@ -77,12 +77,19 @@ class WPTestCase extends Unit
                $_wpTestsBackupStaticAttributesExcludeList;
 
         $backupGlobalsReflectionProperty = new \ReflectionProperty($this, 'backupGlobals');
+        $backupGlobalsReflectionProperty->setAccessible(true);
         $isDefinedInThis = $backupGlobalsReflectionProperty->getDeclaringClass()->getName() !== WPTestCase::class;
         if (!$isDefinedInThis && isset($_wpTestsBackupGlobals) && is_bool($_wpTestsBackupGlobals)) {
             $this->backupGlobals = $_wpTestsBackupGlobals;
         }
 
-        $backupGlobalsExcludeListReflectionProperty = new \ReflectionProperty($this, 'backupGlobalsExcludeList');
+        if (property_exists($this, 'backupGlobalsExcludeList')) {
+            $backupGlobalsExcludeListReflectionProperty = new \ReflectionProperty($this, 'backupGlobalsExcludeList');
+        } else {
+            // Older versions of PHPUnit.
+            $backupGlobalsExcludeListReflectionProperty = new \ReflectionProperty($this, 'backupGlobalsBlacklist');
+        }
+        $backupGlobalsExcludeListReflectionProperty->setAccessible(true);
         $isDefinedInThis = $backupGlobalsExcludeListReflectionProperty->getDeclaringClass()
                 ->getName() !== WPTestCase::class;
         if (!$isDefinedInThis
@@ -96,16 +103,26 @@ class WPTestCase extends Unit
         }
 
         $backupStaticAttributesReflectionProperty = new \ReflectionProperty($this, 'backupStaticAttributes');
+        $backupStaticAttributesReflectionProperty->setAccessible(true);
         $isDefinedInThis = $backupStaticAttributesReflectionProperty->getDeclaringClass()
                 ->getName() !== WPTestCase::class;
         if (!$isDefinedInThis && isset($_wpTestsBackupStaticAttributes) && is_bool($_wpTestsBackupStaticAttributes)) {
             $this->backupStaticAttributes = $_wpTestsBackupStaticAttributes;
         }
 
-        $backupStaticAttributesExcludeListReflectionProperty = new \ReflectionProperty(
-            $this,
-            'backupStaticAttributesExcludeList'
-        );
+        if (property_exists($this, 'backupStaticAttributesExcludeList')) {
+            $backupStaticAttributesExcludeListReflectionProperty = new \ReflectionProperty(
+                $this,
+                'backupStaticAttributesExcludeList'
+            );
+        } else {
+            // Older versions of PHPUnit.
+            $backupStaticAttributesExcludeListReflectionProperty = new \ReflectionProperty(
+                $this,
+                'backupStaticAttributesBlacklist'
+            );
+        }
+        $backupStaticAttributesExcludeListReflectionProperty->setAccessible(true);
         $isDefinedInThis = $backupStaticAttributesExcludeListReflectionProperty->getDeclaringClass()
                 ->getName() !== WPTestCase::class;
         if (!$isDefinedInThis

--- a/src/TestCase/WPTestCase.php
+++ b/src/TestCase/WPTestCase.php
@@ -42,6 +42,7 @@ class WPTestCase extends Unit
         // Additional globals.
         '_wp_registered_theme_features',
         // wp-browser
+        '_wpBrowserWorkerClosure',
         '_wpTestsBackupGlobals',
         '_wpTestsBackupGlobalsExcludeList',
         '_wpTestsBackupStaticAttributes',


### PR DESCRIPTION
- refactor(WPTestCase) handle older PHPUnit versions
- fix(Loop) push only on count > 0
- fix(worker-script) unset globals before run
