### PR TITLE
fix(build) wp-cli/wp-cli-bundle missing from composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## Added
+
+- move `wp-cli/wp-cli-bundle` from `require-dev` to `require` to restore pre-existing support
+
 ## [3.2.2] 2023-11-20;
 
 ## Added

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
     "victorjonsson/markdowndocs": "dev-master",
     "gumlet/php-image-resize": "^1.6",
     "vlucas/phpdotenv": "^3.0",
-    "wp-cli/wp-cli-bundle": "*",
     "symfony/translation": "^3.4"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "bordoni/phpass": "^0.3",
     "mikemclin/laravel-wp-password": "~2.0.0",
     "wp-cli/wp-cli": ">=2.0 <3.0.0",
+    "wp-cli/wp-cli-bundle": "*",
     "zordius/lightncandy": "^1.2",
     "vria/nodiacritic": "^0.1.2",
     "codeception/module-asserts": "^1.0",


### PR DESCRIPTION
Without wp-cli-bundle, WP plugins that rely on it (e.g. Buddypress extending WP_CLI\CommandWithDBObject) will cause a fatal error when running tests.