### PR TITLE
Simplify typos configuration

### DIFF
--- a/config/typos.toml
+++ b/config/typos.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
     ".git/",
     "includes/",
+    "vendor/",
 ]
 ignore-hidden = false
 

--- a/config/typos.toml
+++ b/config/typos.toml
@@ -1,10 +1,9 @@
-[default.extend-identifiers]
-RebOOter = "RebOOter"
 [files]
-extend-exclude = ["vendor", "includes"]
-[type.css]
-extend-glob = ["*.min.css", "*.min.css.map"]
-check-file = false
-[type.js]
-extend-glob = ["*.min.js", "*.min.js.map"]
-check-file = false
+extend-exclude = [
+    ".git/",
+    "includes/",
+]
+ignore-hidden = false
+
+[default.extend-identifiers]
+"RebOOter" = "RebOOter"


### PR DESCRIPTION
`typos` works on the filesystem, not on git index.
So in a not clean local environment it may pick up gitignored files.

I leave it up to you.
Although listing ignored files in this config file is not sustainable.

