### PR TITLE
Remove unnecessary namespace from generated Cest

### DIFF
--- a/src/Project/PluginProject.php
+++ b/src/Project/PluginProject.php
@@ -147,7 +147,7 @@ class PluginProject extends ContentProject
 
 namespace Tests\\EndToEnd;
 
-use Tests\\Support\\EndToEndTester;
+use EndToEndTester;
 
 class ActivationCest
 {


### PR DESCRIPTION
EndToEnd tester is created to use EndToEndTester with a Test\Support namespace which throws an error because EndToEnd tester does not have a namespace.

![CleanShot 2024-03-21 at 15 29 00@2x](https://github.com/lucatume/wp-browser/assets/6947218/1b40dd9e-6803-4123-82c2-9b5223a0c88a)


Once you remove the `Tests\Support\` namespace, the test completes as expected.

![CleanShot 2024-03-21 at 15 30 54@2x](https://github.com/lucatume/wp-browser/assets/6947218/cfe9638f-cc7a-49e6-8df9-8317f1356540)
