### PR TITLE
Fix issue #720

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## Fixed
+
+- Avoid calling `wpdb::db_connect()` twice during `WPLoader` bootstrap. (thanks @calvinalkan)
+
 ## [4.1.8] 2024-05-13;
 
 ### Changed

--- a/config/patches/core-phpunit/includes/abstract-testcase.php.patch
+++ b/config/patches/core-phpunit/includes/abstract-testcase.php.patch
@@ -1,5 +1,5 @@
 diff --git a/includes/core-phpunit/includes/abstract-testcase.php b/includes/core-phpunit/includes/abstract-testcase.php
-index 3600722f..67c4d71c 100644
+index f2978644..e092beca 100644
 --- a/includes/core-phpunit/includes/abstract-testcase.php
 +++ b/includes/core-phpunit/includes/abstract-testcase.php
 @@ -20,6 +20,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
@@ -29,16 +29,23 @@ index 3600722f..67c4d71c 100644
  	}
  
  	/**
-@@ -69,7 +71,7 @@ public static function set_up_before_class() {
- 		$wpdb->db_connect();
- 		ini_set( 'display_errors', 1 );
+@@ -66,10 +68,12 @@ public static function set_up_before_class() {
+ 
+ 		$wpdb->suppress_errors = false;
+ 		$wpdb->show_errors     = true;
+-		$wpdb->db_connect();
+-		ini_set( 'display_errors', 1 );
++        if ( ! $wpdb->check_connection() ) {
++            $wpdb->db_connect();
++        }
++        ini_set( 'display_errors', 1 );
  
 -		$class = get_called_class();
 +		$class = self::$calledClass ?? get_called_class();
  
  		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
  			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );
-@@ -82,7 +84,7 @@ public static function set_up_before_class() {
+@@ -82,7 +86,7 @@ public static function set_up_before_class() {
  	 * Runs the routine after all tests have been run.
  	 */
  	public static function tear_down_after_class() {
@@ -47,7 +54,7 @@ index 3600722f..67c4d71c 100644
  
  		if ( method_exists( $class, 'wpTearDownAfterClass' ) ) {
  			call_user_func( array( $class, 'wpTearDownAfterClass' ) );
-@@ -646,7 +648,7 @@ public function expectedDeprecated() {
+@@ -651,7 +655,7 @@ public function expectedDeprecated() {
  	 *
  	 * @since 4.2.0
  	 */
@@ -56,7 +63,7 @@ index 3600722f..67c4d71c 100644
  		$this->expectedDeprecated();
  	}
  
-@@ -1655,4 +1657,9 @@ public static function touch( $file ) {
+@@ -1660,4 +1664,9 @@ public static function touch( $file ) {
  
  		touch( $file );
  	}

--- a/includes/core-phpunit/includes/abstract-testcase.php
+++ b/includes/core-phpunit/includes/abstract-testcase.php
@@ -20,8 +20,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	protected $expected_doing_it_wrong = array();
 	protected $caught_doing_it_wrong   = array();
 
-    private static ?string $calledClass = null;
-
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
 
@@ -39,7 +37,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 *
 	 * @return WP_UnitTest_Factory The fixture factory.
 	 */
-	public static function factory() {
+	protected static function factory() {
 		static $factory = null;
 		if ( ! $factory ) {
 			$factory = new WP_UnitTest_Factory();
@@ -55,7 +53,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * @return string The class name.
 	 */
 	public static function get_called_class() {
-		return self::$called_class ?? get_called_class();
+		return get_called_class();
 	}
 
 	/**
@@ -71,7 +69,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$wpdb->db_connect();
 		ini_set( 'display_errors', 1 );
 
-		$class = self::$calledClass ?? get_called_class();
+		$class = get_called_class();
 
 		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
 			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );
@@ -84,7 +82,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * Runs the routine after all tests have been run.
 	 */
 	public static function tear_down_after_class() {
-        $class = self::$calledClass ?? get_called_class();
+		$class = get_called_class();
 
 		if ( method_exists( $class, 'wpTearDownAfterClass' ) ) {
 			call_user_func( array( $class, 'wpTearDownAfterClass' ) );
@@ -653,7 +651,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 *
 	 * @since 4.2.0
 	 */
-	public function assert_post_conditions() {
+	protected function assert_post_conditions() {
 		$this->expectedDeprecated();
 	}
 
@@ -1661,10 +1659,5 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		}
 
 		touch( $file );
-	}
-
-	public function setCalledClass(string $class): void
-	{
-		self::$calledClass = $class;
 	}
 }

--- a/includes/core-phpunit/includes/abstract-testcase.php
+++ b/includes/core-phpunit/includes/abstract-testcase.php
@@ -20,6 +20,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	protected $expected_doing_it_wrong = array();
 	protected $caught_doing_it_wrong   = array();
 
+    private static ?string $calledClass = null;
+
 	protected static $hooks_saved = array();
 	protected static $ignore_files;
 
@@ -37,7 +39,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 *
 	 * @return WP_UnitTest_Factory The fixture factory.
 	 */
-	protected static function factory() {
+	public static function factory() {
 		static $factory = null;
 		if ( ! $factory ) {
 			$factory = new WP_UnitTest_Factory();
@@ -53,7 +55,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * @return string The class name.
 	 */
 	public static function get_called_class() {
-		return get_called_class();
+		return self::$called_class ?? get_called_class();
 	}
 
 	/**
@@ -66,10 +68,12 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 
 		$wpdb->suppress_errors = false;
 		$wpdb->show_errors     = true;
-		$wpdb->db_connect();
-		ini_set( 'display_errors', 1 );
+        if ( ! $wpdb->check_connection() ) {
+            $wpdb->db_connect();
+        }
+        ini_set( 'display_errors', 1 );
 
-		$class = get_called_class();
+		$class = self::$calledClass ?? get_called_class();
 
 		if ( method_exists( $class, 'wpSetUpBeforeClass' ) ) {
 			call_user_func( array( $class, 'wpSetUpBeforeClass' ), static::factory() );
@@ -82,7 +86,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 * Runs the routine after all tests have been run.
 	 */
 	public static function tear_down_after_class() {
-		$class = get_called_class();
+        $class = self::$calledClass ?? get_called_class();
 
 		if ( method_exists( $class, 'wpTearDownAfterClass' ) ) {
 			call_user_func( array( $class, 'wpTearDownAfterClass' ) );
@@ -651,7 +655,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 *
 	 * @since 4.2.0
 	 */
-	protected function assert_post_conditions() {
+	public function assert_post_conditions() {
 		$this->expectedDeprecated();
 	}
 
@@ -1659,5 +1663,10 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		}
 
 		touch( $file );
+	}
+
+	public function setCalledClass(string $class): void
+	{
+		self::$calledClass = $class;
 	}
 }


### PR DESCRIPTION
Update the Core PHPUnit suite patch to avoid calling `wpdb::db_connect` twice.  
The first time when the `wp-settings.php` file is loaded as part of the `WPLoader` bootstrap phase, the second time during `WPTestCase::setUpBeforeClass`.

Fixes #720 
