### PR TITLE
Support arbitrary paths for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Added
+
+- Allow plugins to be loaded from arbitrary paths in the `WPLoader` module.
+
 ## [4.1.9] 2024-05-18;
 
 ## Fixed

--- a/docs/modules/WPLoader.md
+++ b/docs/modules/WPLoader.md
@@ -46,16 +46,18 @@ When used in this mode, the module supports the following configuration paramete
   and control the WordPress testing environment.
 * `pluginsFolder` - the path to the plugins folder to use when loading WordPress. Equivalent to defining the
   `WP_PLUGIN_DIR` constant.
-* `plugins` - a list of plugins to activate and load in the WordPress installation. Each plugin must be specified in a
-  format like `hello.php` or `my-plugin/my-plugin.php` format.
+* `plugins` - a list of plugins to activate and load in the WordPress installation. If the plugin is located in the
+  WordPress installation plugins directory, then the plugin name can be specified using the `directory/file.php` format.
+  If the plugin is located in an arbitrary path inside or outiside of the WordPress installation or project, then the
+  plugin name must be specified either as an absolute path or as a relative path to the project root folder.
 * `silentlyActivatePlugins` - a list of plugins to activate **silently**, without firing their activation hooks.
   Depending on the plugin, a silent activation might cause the plugin to not work correctly. The list must be in the
   same format as the `plugins` parameter and plugin should be activated silently only if they are not working correctly
-  during normal activation and are known to work correctly when activated silently.
+  during normal activation and are known to work correctly when activated silently. Plugin paths can be specified
+  following the same format of the `plugins` parameter.
 * `bootstrapActions` - a list of actions or callables to call **after** WordPress is loaded and before the tests run.
 * `theme` - the theme to activate and load in the WordPress installation. The theme must be specified in slug format
-  like
-  `twentytwentythree`.
+  like `twentytwentythree`.
 * `AUTH_KEY` - the `AUTH_KEY` constant value to use when loading WordPress. If the `wpRootFolder` path points at a
   configured installation, containing the `wp-config.php` file, then the value of the constant in the configuration file
   will be used, else it will be randomly generated.
@@ -126,9 +128,10 @@ modules:
         adminEmail: admin@wordpress.test
         title: 'Integration Tests'
         plugins:
-          - hello.php
-          - woocommerce/woocommerce.php
-          - my-plugin/my-plugin.php
+          - hello.php # This plugin will be loaded from the WordPress installation plugins directory.
+          - /home/plugins/woocommerce/woocommerce.php # This plugin will be loaded from an arbitrary absolute path.
+          - vendor/acme/project/plugin.php # This plugin will be loaded from an arbitrary relative path inside the project root folder.
+          - my-plugin.php # This plugin will be loaded from the project root folder.
         theme: twentytwentythree
 ```
 
@@ -148,9 +151,10 @@ modules:
         adminEmail: '%WP_ADMIN_EMAIL%'
         title: '%WP_TITLE%'
         plugins:
-          - hello.php
-          - woocommerce/woocommerce.php
-          - my-plugin/my-plugin.php
+          - hello.php # This plugin will be loaded from the WordPress installation plugins directory.
+          - /home/plugins/woocommerce/woocommerce.php # This plugin will be loaded from an arbitrary absolute path.
+          - my-plugin.php # This plugin will be loaded from the project root folder.
+          - vendor/acme/project/plugin.php # This plugin will be loaded from an arbitrary relative path inside the project root folder.
         theme: twentytwentythree
 ```
 

--- a/src/Module/WPLoader.php
+++ b/src/Module/WPLoader.php
@@ -622,17 +622,17 @@ class WPLoader extends Module
         $skipInstall = ($this->config['skipInstall'] ?? false)
             && !Debug::isEnabled()
             && $this->isWordPressInstalled();
+        $isMultisite = $this->config['multisite'];
+        $plugins = (array)$this->config['plugins'];
 
         Dispatcher::dispatch(self::EVENT_BEFORE_INSTALL, $this);
 
         if (!$skipInstall) {
             putenv('WP_TESTS_SKIP_INSTALL=0');
-            $isMultisite = $this->config['multisite'];
-            $plugins = (array)$this->config['plugins'];
 
             /*
              * The bootstrap file will load the `wp-settings.php` one that will load plugins and the theme.
-             * Hook on the option to get the the active plugins to run the plugins' and theme activation
+             * Hook on the option to get the active plugins to run the plugins' and theme activation
              * in a separate process.
              */
             if ($isMultisite) {
@@ -654,6 +654,8 @@ class WPLoader extends Module
             putenv('WP_TESTS_SKIP_INSTALL=1');
         }
 
+        $silentPlugins = $this->config['silentlyActivatePlugins'];
+        $this->includeAllPlugins(array_merge($plugins, $silentPlugins), $isMultisite);
         $this->includeCorePHPUniteSuiteBootstrapFile();
 
         Dispatcher::dispatch(self::EVENT_AFTER_INSTALL, $this);
@@ -1029,7 +1031,15 @@ class WPLoader extends Module
         // Flush the cache to force the refetch of the options' value.
         wp_cache_delete('alloptions', 'options');
 
-        return $plugins;
+        // Do not include external plugins, it would create issues at this stage.
+        $pluginsDir = $this->installation->getPluginsDir();
+
+        return array_values(
+            array_filter(
+                $plugins,
+                static fn(string $plugin) => is_file($pluginsDir . "/$plugin")
+            )
+        );
     }
 
     /**
@@ -1062,8 +1072,22 @@ class WPLoader extends Module
         // Flush the cache to force the refetch of the options' value.
         wp_cache_delete("1::active_sitewide_plugins", 'site-options');
 
+        // Do not include external plugins, it would create issues at this stage.
+        $pluginsDir = $this->installation->getPluginsDir();
+        $validPlugins = array_values(
+            array_filter(
+                $plugins,
+                static fn(string $plugin) => is_file($pluginsDir . "/$plugin")
+            )
+        );
+
         // Format for site-wide active plugins is `[ 'plugin-slug/plugin.php' => timestamp ]`.
-        return array_combine($plugins, array_fill(0, count($plugins), time()));
+        $validActiveSitewidePlugins = array_combine(
+            $validPlugins,
+            array_fill(0, count($validPlugins), time())
+        );
+
+        return $validActiveSitewidePlugins;
     }
 
     private function isWordPressInstalled(): bool
@@ -1077,5 +1101,55 @@ class WPLoader extends Module
         } catch (Throwable) {
             return false;
         }
+    }
+
+    /**
+     * @param string[] $plugins
+     * @throws ModuleConfigException
+     */
+    private function includeAllPlugins(array $plugins, bool $isMultisite): void
+    {
+        PreloadFilters::addFilter('plugins_loaded', function () use ($plugins, $isMultisite) {
+            $activePlugins = $isMultisite ? get_site_option('active_sitewide_plugins') : get_option('active_plugins');
+
+            if (!is_array($activePlugins)) {
+                $activePlugins = [];
+            }
+
+            $pluginsDir = $this->installation->getPluginsDir();
+
+            foreach ($plugins as $plugin) {
+                if (!is_file($pluginsDir . "/$plugin")) {
+                    $pluginRealPath = realpath($plugin);
+
+                    if (!$pluginRealPath) {
+                        throw new ModuleConfigException(
+                            __CLASS__,
+                            "Plugin file $plugin does not exist."
+                        );
+                    }
+
+                    include_once $pluginRealPath;
+
+                    // Create a name for the external plugin in the format <directory>/<file.php>.
+                    $plugin = basename(dirname($pluginRealPath)) . '/' . basename($pluginRealPath);
+                }
+
+                if ($isMultisite) {
+                    // Network-activated plugins are stored in the format <plugins_name> => <timestamp>.
+                    $activePlugins[$plugin] = time();
+                } else {
+                    $activePlugins[] = $plugin;
+                }
+            }
+
+
+            // Update the active plugins to include all plugins, external or not.
+            if ($isMultisite) {
+                update_site_option('active_sitewide_plugins', $activePlugins);
+            } else {
+                update_option('active_plugins', array_values(array_unique($activePlugins)));
+            }
+        }, -100000);
     }
 }

--- a/src/WordPress/CodeExecution/ActivatePluginAction.php
+++ b/src/WordPress/CodeExecution/ActivatePluginAction.php
@@ -7,6 +7,7 @@ use lucatume\WPBrowser\Exceptions\RuntimeException;
 use lucatume\WPBrowser\WordPress\FileRequests\FileRequest;
 use lucatume\WPBrowser\WordPress\InstallationException;
 use WP_Error;
+
 use function activate_plugin;
 
 class ActivatePluginAction implements CodeExecutionActionInterface
@@ -33,7 +34,13 @@ class ActivatePluginAction implements CodeExecutionActionInterface
     private function activatePlugin(string $plugin, bool $multisite, bool $silent = false): void
     {
         require_once ABSPATH . 'wp-admin/includes/plugin.php';
-        $activated = activate_plugin($plugin, '', $multisite, $silent);
+
+        if (file_exists(WP_PLUGIN_DIR . '/' . $plugin)) {
+            $activated = activate_plugin($plugin, '', $multisite, $silent);
+        } else {
+            [$activated, $plugin] = $this->activateExternalPlugin($plugin, $multisite, $silent);
+        }
+
         $activatedString = $multisite ? 'network activated' : 'activated';
         $message = "Plugin $plugin could not be $activatedString.";
 
@@ -41,7 +48,7 @@ class ActivatePluginAction implements CodeExecutionActionInterface
             $message = $activated->get_error_message();
             $data = $activated->get_error_data();
             if ($data && is_string($data)) {
-                $message .= ": $data";
+                $message = substr($message, 0, -1) . ": $data";
             }
             throw new InstallationException(trim($message));
         }
@@ -51,6 +58,60 @@ class ActivatePluginAction implements CodeExecutionActionInterface
         if (!$isActive) {
             throw new RuntimeException($message);
         }
+    }
+
+    /**
+     * @return array{0: bool|WP_Error, 1: string}
+     */
+    private function activateExternalPlugin(
+        string $plugin,
+        bool $multisite,
+        bool $silent = false
+    ): array {
+        ob_start();
+        try {
+            $pluginRealpath = realpath($plugin);
+
+            if (!$pluginRealpath) {
+                return [new \WP_Error('plugin_not_found', "Plugin file $plugin does not exist."), ''];
+            }
+
+            // Get the plugin name in the `plugin/plugin-file.php` format.
+            $pluginWpName = basename(dirname($pluginRealpath)) . '/' . basename($pluginRealpath);
+
+            include_once $pluginRealpath;
+
+            if (!$silent) {
+                do_action('activate_plugin', $pluginWpName, $multisite);
+                $pluginNameForActivationHook = ltrim($pluginRealpath, '\\/');
+                do_action("activate_{$pluginNameForActivationHook}", $multisite);
+            }
+
+            $activePlugins = $multisite ? get_site_option('active_sitewide_plugins') : get_option('active_plugins');
+
+            if (!is_array($activePlugins)) {
+                $activePlugins = [];
+            }
+
+            if ($multisite) {
+                // Network-activated plugins are stored in the format <plugins_name> => <timestamp>.
+                $activePlugins[$pluginWpName] = time();
+                update_site_option('active_sitewide_plugins', $activePlugins);
+            } else {
+                $activePlugins[] = $pluginWpName;
+                update_option('active_plugins', $activePlugins);
+            }
+        } catch (\Throwable $t) {
+            return [new \WP_Error('plugin_activation_failed', $t->getMessage()), ''];
+        }
+
+        $output = ob_get_clean();
+
+        if ($output) {
+            return [new \WP_Error('plugin_activation_output', $output), $pluginWpName];
+        }
+
+        return [true, $pluginWpName];
     }
 
     public function getClosure(): Closure

--- a/tests/_data/plugins/exploding-plugin/main.php
+++ b/tests/_data/plugins/exploding-plugin/main.php
@@ -1,0 +1,10 @@
+<?php
+/** Plugin Name: Exploding Plugin */
+
+function exploding_plugin_main(){}
+
+register_activation_hook( __FILE__, 'exploding_plugin_main_activation' );
+function exploding_plugin_main_activation(){
+    update_option('exploding_plugin_activated', 1);
+    throw new \RuntimeException('Boom');
+}

--- a/tests/_data/plugins/some-external-plugin/some-plugin.php
+++ b/tests/_data/plugins/some-external-plugin/some-plugin.php
@@ -1,0 +1,9 @@
+<?php
+/** Plugin Name: Some Plugin */
+
+function some_plugin_main(){}
+
+register_activation_hook( __FILE__, 'some_plugin_activation' );
+function some_plugin_activation(){
+    update_option('some_plugin_activated', 1);
+}

--- a/tests/_support/Traits/LoopIsolation.php
+++ b/tests/_support/Traits/LoopIsolation.php
@@ -3,12 +3,10 @@
 namespace lucatume\WPBrowser\Tests\Traits;
 
 use Closure;
-use Codeception\Codecept;
 use Codeception\Util\Debug;
 use lucatume\WPBrowser\Process\Loop;
 use lucatume\WPBrowser\Process\ProcessException;
 use lucatume\WPBrowser\Process\WorkerException;
-use lucatume\WPBrowser\Utils\Codeception;
 use lucatume\WPBrowser\Utils\Property;
 use ReflectionObject;
 use Throwable;

--- a/tests/unit/lucatume/WPBrowser/Module/WPLoaderTest.php
+++ b/tests/unit/lucatume/WPBrowser/Module/WPLoaderTest.php
@@ -1205,7 +1205,7 @@ class WPLoaderTest extends Unit
 
         $this->expectException(ModuleException::class);
         $this->expectExceptionMessage(
-            'Failed to activate plugin some-plugin/some-plugin.php. Plugin file does not exist.'
+            'Failed to activate plugin some-plugin/some-plugin.php. Plugin file some-plugin/some-plugin.php does not exist.'
         );
 
         $wpLoader = $this->module();
@@ -1245,7 +1245,7 @@ class WPLoaderTest extends Unit
 
         $this->expectException(ModuleException::class);
         $this->expectExceptionMessage(
-            'Failed to activate plugin some-plugin/some-plugin.php. Plugin file does not exist.'
+            'Failed to activate plugin some-plugin/some-plugin.php. Plugin file some-plugin/some-plugin.php does not exist.'
         );
 
         $wpLoader = $this->module();
@@ -2736,6 +2736,289 @@ PHP
 
                 Assert::assertEquals('', get_option('my_plugin_activated'));
                 Assert::assertEquals('__loaded__', get_option('my_plugin_loaded'));
+            }
+        );
+    }
+
+    /**
+     * It should allow loading a plugin from an arbitrary path
+     *
+     * @test
+     */
+    public function should_allow_loading_a_plugin_from_an_arbitrary_path(): void
+    {
+        $myPluginCode = <<< PHP
+<?php
+/** Plugin Name: My Plugin */
+function my_plugin_main() { }
+
+register_activation_hook( __FILE__, 'activate_my_plugin' );
+function activate_my_plugin(){
+    update_option('my_plugin_activated', '1');
+}
+PHP;
+        $projectDir = FS::tmpDir('wploader_', [
+            'my-plugin.php' => $myPluginCode,
+
+            'var' => [
+                'wordpress' => []
+            ],
+            'vendor' => [
+                'acme' => [
+
+                ]
+            ]
+        ]);
+        $wpRootDir = $projectDir. '/var/wordpress';
+        $installation = Installation::scaffold($wpRootDir);
+        $dbName = Random::dbName();
+        $dbHost = Env::get('WORDPRESS_DB_HOST');
+        $dbUser = Env::get('WORDPRESS_DB_USER');
+        $dbPassword = Env::get('WORDPRESS_DB_PASSWORD');
+        $installationDb = new MysqlDatabase($dbName, $dbUser, $dbPassword, $dbHost, 'wp_');
+        // Copy WooCommerce from the main installation to a temporary directory.
+        $tmpDir = sys_get_temp_dir();
+        $mainWPInstallationRootDir = Env::get('WORDPRESS_ROOT_DIR');
+        if (!FS::recurseCopy(
+            $mainWPInstallationRootDir . '/wp-content/plugins/woocommerce',
+            $tmpDir . '/external-woocommerce'
+        )) {
+            throw new \RuntimeException('Could not copy plugin woocommerce');
+        }
+        $externalAbsolutePathPluginDir = $tmpDir . '/external-woocommerce';
+        $this->assertFileExists($externalAbsolutePathPluginDir . '/woocommerce.php');
+        if(!FS::recurseCopy(
+            codecept_data_dir('plugins/some-external-plugin'),
+            $projectDir . '/vendor/acme/some-external-plugin'
+        )){
+            throw new \RuntimeException('Could not copy plugin some-external-plugin');
+        }
+
+        $hash = md5(microtime());
+        $externalExplodingPlugin = sys_get_temp_dir() . '/' . $hash . '/exploding-plugin';
+        if(!(mkdir($externalExplodingPlugin, 0777, true) && is_dir($externalExplodingPlugin))){
+            throw new \RuntimeException('Could not create exploding plugin directory');
+        }
+        if(!copy(codecept_data_dir('plugins/exploding-plugin/main.php'),$externalExplodingPlugin . '/main.php' )){
+            throw new \RuntimeException('Could not copy exploding plugin file');
+        }
+        $testPluginFileContents = <<< PHP
+<?php
+/** Plugin Name: Test Plugin */
+function test_plugin_main() { }
+
+register_activation_hook( __FILE__, 'test_plugin_activate' );
+function test_plugin_activate() {
+    update_option('test_plugin_activated', '1');
+}
+PHP;
+
+        if(!file_put_contents($wpRootDir. '/wp-content/plugins/test.php', $testPluginFileContents)){
+            throw new \RuntimeException('Could not write test.php plugin file');
+        }
+
+        // Create a configuration to load the plugins from arbitrary paths.
+        $this->config = [
+            'wpRootFolder' => $wpRootDir,
+            'dbUrl' => $installationDb->getDbUrl(),
+            'tablePrefix' => 'test_',
+            'plugins' => [
+                'test.php', // From the WordPress installation plugins directory.
+                $externalAbsolutePathPluginDir . '/woocommerce.php', // Absolute path.
+                'vendor/acme/some-external-plugin/some-plugin.php', // Relative path to the project root folder.
+                'my-plugin.php' // Relative path to the project root folder, development plugin file.
+            ],
+            'silentlyActivatePlugins' => [
+                $externalExplodingPlugin . '/main.php' // Absolute path.
+            ]
+        ];
+
+        $wpLoader = $this->module();
+        $projectDirname = basename($projectDir);
+
+        $this->assertInIsolation(
+            static function () use ($wpLoader, $projectDir) {
+                chdir($projectDir);
+                $projectDirname = basename($projectDir);
+
+                $wpLoader->_initialize();
+
+                Assert::assertEquals([
+                    'test.php',
+                    'external-woocommerce/woocommerce.php',
+                    'some-external-plugin/some-plugin.php',
+                    "$projectDirname/my-plugin.php",
+                    'exploding-plugin/main.php'
+                ], get_option('active_plugins'));
+
+                // Test plugin from the WordPress installation plugins directory.
+                Assert::assertEquals('1', get_option('test_plugin_activated'));
+                Assert::assertTrue(function_exists('test_plugin_main'));
+
+                // WooCommerce from the absolute path.
+                Assert::assertTrue(function_exists('wc_get_product'));
+                Assert::assertTrue(class_exists('WC_Product'));
+                $product = new \WC_Product();
+                $product->set_name('Test Product');
+                $product->set_price(10);
+                $product->set_status('publish');
+                $product->save();
+                Assert::assertInstanceOf(\WC_Product::class, $product);
+                Assert::assertInstanceOf(\WC_Product::class, wc_get_product($product->get_id()));
+
+                // Some external plugin from the relative path.
+                Assert::assertTrue(function_exists('some_plugin_main'));
+                Assert::assertEquals('1', get_option('some_plugin_activated'));
+
+                // My plugin from the relative path.
+                Assert::assertTrue(function_exists('my_plugin_main'));
+                Assert::assertEquals('1', get_option('my_plugin_activated'));
+
+                // Exploding plugin from the absolute path.
+                Assert::assertTrue(function_exists('exploding_plugin_main'));
+                Assert::assertEquals('', get_option('exploding_plugin_activated'));
+            }
+        );
+    }
+
+    /**
+     * It should allow loading a plugin from an arbitrary path in multisite
+     *
+     * @test
+     */
+    public function should_allow_loading_a_plugin_from_an_arbitrary_path_in_multisite(): void
+    {
+        $myPluginCode = <<< PHP
+<?php
+/** Plugin Name: My Plugin */
+function my_plugin_main() { }
+
+register_activation_hook( __FILE__, 'activate_my_plugin' );
+function activate_my_plugin(){
+    update_option('my_plugin_activated', '1');
+}
+PHP;
+        $projectDir = FS::tmpDir('wploader_', [
+            'my-plugin.php' => $myPluginCode,
+
+            'var' => [
+                'wordpress' => []
+            ],
+            'vendor' => [
+                'acme' => [
+
+                ]
+            ]
+        ]);
+        $wpRootDir = $projectDir. '/var/wordpress';
+        $installation = Installation::scaffold($wpRootDir);
+        $dbName = Random::dbName();
+        $dbHost = Env::get('WORDPRESS_DB_HOST');
+        $dbUser = Env::get('WORDPRESS_DB_USER');
+        $dbPassword = Env::get('WORDPRESS_DB_PASSWORD');
+        $installationDb = new MysqlDatabase($dbName, $dbUser, $dbPassword, $dbHost, 'wp_');
+        // Copy WooCommerce from the main installation to a temporary directory.
+        $tmpDir = sys_get_temp_dir();
+        $mainWPInstallationRootDir = Env::get('WORDPRESS_ROOT_DIR');
+        if (!FS::recurseCopy(
+            $mainWPInstallationRootDir . '/wp-content/plugins/woocommerce',
+            $tmpDir . '/external-woocommerce'
+        )) {
+            throw new \RuntimeException('Could not copy plugin woocommerce');
+        }
+        $externalAbsolutePathPluginDir = $tmpDir . '/external-woocommerce';
+        $this->assertFileExists($externalAbsolutePathPluginDir . '/woocommerce.php');
+        if(!FS::recurseCopy(
+            codecept_data_dir('plugins/some-external-plugin'),
+            $projectDir . '/vendor/acme/some-external-plugin'
+        )){
+            throw new \RuntimeException('Could not copy plugin some-external-plugin');
+        }
+
+        $hash = md5(microtime());
+        $externalExplodingPlugin = sys_get_temp_dir() . '/' . $hash . '/exploding-plugin';
+        if(!(mkdir($externalExplodingPlugin, 0777, true) && is_dir($externalExplodingPlugin))){
+            throw new \RuntimeException('Could not create exploding plugin directory');
+        }
+        if(!copy(codecept_data_dir('plugins/exploding-plugin/main.php'),$externalExplodingPlugin . '/main.php' )){
+            throw new \RuntimeException('Could not copy exploding plugin file');
+        }
+        $testPluginFileContents = <<< PHP
+<?php
+/** Plugin Name: Test Plugin */
+function test_plugin_main() { }
+
+register_activation_hook( __FILE__, 'test_plugin_activate' );
+function test_plugin_activate() {
+    update_option('test_plugin_activated', '1');
+}
+PHP;
+
+        if(!file_put_contents($wpRootDir. '/wp-content/plugins/test.php', $testPluginFileContents)){
+            throw new \RuntimeException('Could not write test.php plugin file');
+        }
+
+        // Create a configuration to load the plugins from arbitrary paths.
+        $this->config = [
+            'multisite' => true,
+            'wpRootFolder' => $wpRootDir,
+            'dbUrl' => $installationDb->getDbUrl(),
+            'tablePrefix' => 'test_',
+            'plugins' => [
+                'test.php', // From the WordPress installation plugins directory.
+                $externalAbsolutePathPluginDir . '/woocommerce.php', // Absolute path.
+                'vendor/acme/some-external-plugin/some-plugin.php', // Relative path to the project root folder.
+                'my-plugin.php' // Relative path to the project root folder, development plugin file.
+            ],
+            'silentlyActivatePlugins' => [
+                $externalExplodingPlugin . '/main.php' // Absolute path.
+            ]
+        ];
+
+        $wpLoader = $this->module();
+        $projectDirname = basename($projectDir);
+
+        $this->assertInIsolation(
+            static function () use ($wpLoader, $projectDir) {
+                chdir($projectDir);
+                $projectDirname = basename($projectDir);
+
+                $wpLoader->_initialize();
+
+                Assert::assertEquals([
+                    'test.php',
+                    'external-woocommerce/woocommerce.php',
+                    'some-external-plugin/some-plugin.php',
+                    "$projectDirname/my-plugin.php",
+                    'exploding-plugin/main.php'
+                ], array_keys(get_site_option('active_sitewide_plugins')));
+
+                // Test plugin from the WordPress installation plugins directory.
+                Assert::assertEquals('1', get_option('test_plugin_activated'));
+                Assert::assertTrue(function_exists('test_plugin_main'));
+
+                // WooCommerce from the absolute path.
+                Assert::assertTrue(function_exists('wc_get_product'));
+                Assert::assertTrue(class_exists('WC_Product'));
+                $product = new \WC_Product();
+                $product->set_name('Test Product');
+                $product->set_price(10);
+                $product->set_status('publish');
+                $product->save();
+                Assert::assertInstanceOf(\WC_Product::class, $product);
+                Assert::assertInstanceOf(\WC_Product::class, wc_get_product($product->get_id()));
+
+                // Some external plugin from the relative path.
+                Assert::assertTrue(function_exists('some_plugin_main'));
+                Assert::assertEquals('1', get_option('some_plugin_activated'));
+
+                // My plugin from the relative path.
+                Assert::assertTrue(function_exists('my_plugin_main'));
+                Assert::assertEquals('1', get_option('my_plugin_activated'));
+
+                // Exploding plugin from the absolute path.
+                Assert::assertTrue(function_exists('exploding_plugin_main'));
+                Assert::assertEquals('', get_option('exploding_plugin_activated'));
             }
         );
     }


### PR DESCRIPTION
Allow the `WPLoader` module `plugins` and `silentlyActivatePlugins` parameters to point to arbitrary plugin paths.

The paths can be absolute paths like `/home/projects/my-plugin/plugin.php`, paths relative to the project root directory like `vendor/woocommerce/woocommerce.php`, `directory/file.php` or `file.php` paths relative to the WordPress installation plugins directory.

E.g. this configuration will work:

```yaml
actor: IntegrationTester
bootstrap: _bootstrap.php
modules:
  enabled:
    - \Helper\Integration
    - lucatume\WPBrowser\Module\WPLoader:
        wpRootFolder: /var/wordpress
        dbUrl: mysql://root:root@mysql:3306/wordpress
        tablePrefix: test_
        domain: wordpress.test
        adminEmail: admin@wordpress.test
        title: 'Integration Tests'
        plugins:
          - hello.php # This plugin will be loaded from the WordPress installation plugins directory.
          - /home/plugins/woocommerce/woocommerce.php # This plugin will be loaded from an arbitrary absolute path.
          - vendor/acme/project/plugin.php # This plugin will be loaded from an arbitrary relative path inside the project root folder.
          - my-plugin.php # This plugin will be loaded from the project root folder.
        theme: twentytwentythree
```

