### PR TITLE
Restore compatibility with WordPress <6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Ensure the `WPLoader` module will initialize correctly when used in `loadOnly` mode not using the `EventDispatcherBridge` extension.
+- Ensure the `WPLoader` module will initialize correctly when used in `loadOnly` mode not using the `EventDispatcherBridge` extension. (thanks @lxbdr)
+- Support loading the `wpdb` class from either the `class-wpdb.php` file or the `wp-db.php` one, supporting older versions of WordPress (thanks @BrianHenryIE)
 
 ## [4.2.5] 2024-06-26;
 

--- a/bin/update_core_phpunit_includes
+++ b/bin/update_core_phpunit_includes
@@ -16,6 +16,7 @@ rm -rf "${root_dir}"/includes/core-phpunit/includes &&
   cd .. &&
   mv  wordpress-develop/tests/phpunit/includes ./includes &&
   rm -rf wordpress-develop &&
+  git apply "${root_dir}"/config/patches/core-phpunit/includes/install.php.patch &&
   git apply "${root_dir}"/config/patches/core-phpunit/includes/abstract-testcase.php.patch &&
   git apply "${root_dir}"/config/patches/core-phpunit/includes/testcase-ajax.php.patch &&
   git apply "${root_dir}"/config/patches/core-phpunit/includes/testcase-canonical.php.patch &&

--- a/config/patches/core-phpunit/includes/install.php.patch
+++ b/config/patches/core-phpunit/includes/install.php.patch
@@ -1,0 +1,23 @@
+diff --git a/includes/core-phpunit/includes/install.php b/includes/core-phpunit/includes/install.php
+index 8a595903..dbb13b5f 100644
+--- a/includes/core-phpunit/includes/install.php
++++ b/includes/core-phpunit/includes/install.php
+@@ -40,8 +40,17 @@
+ require_once ABSPATH . 'wp-settings.php';
+ 
+ require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+-require_once ABSPATH . 'wp-includes/class-wpdb.php';
+ 
++/**
++ * File was renamed in WordPress 6.1.
++ *
++ * @see https://core.trac.wordpress.org/ticket/56268
++ * @see https://github.com/WordPress/WordPress/commit/8484c7babb6b6ee951f83babea656a294157665d
++ */
++require_once file_exists( ABSPATH . 'wp-includes/class-wpdb.php' )
++    ? ABSPATH . 'wp-includes/class-wpdb.php'
++    : ABSPATH . 'wp-includes/wp-db.php';
++ 
+ // Override the PHPMailer.
+ global $phpmailer;
+ require_once __DIR__ . '/mock-mailer.php';

--- a/includes/core-phpunit/includes/install.php
+++ b/includes/core-phpunit/includes/install.php
@@ -40,8 +40,17 @@ tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 require_once ABSPATH . 'wp-settings.php';
 
 require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-require_once ABSPATH . 'wp-includes/class-wpdb.php';
 
+/**
+ * File was renamed in WordPress 6.1.
+ *
+ * @see https://core.trac.wordpress.org/ticket/56268
+ * @see https://github.com/WordPress/WordPress/commit/8484c7babb6b6ee951f83babea656a294157665d
+ */
+require_once file_exists( ABSPATH . 'wp-includes/class-wpdb.php' )
+    ? ABSPATH . 'wp-includes/class-wpdb.php'
+    : ABSPATH . 'wp-includes/wp-db.php';
+ 
 // Override the PHPMailer.
 global $phpmailer;
 require_once __DIR__ . '/mock-mailer.php';

--- a/includes/core-phpunit/includes/install.php
+++ b/includes/core-phpunit/includes/install.php
@@ -40,16 +40,7 @@ tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 require_once ABSPATH . 'wp-settings.php';
 
 require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-
-/**
- * File was renamed in WordPress 6.1.
- *
- * @see https://core.trac.wordpress.org/ticket/56268
- * @see https://github.com/WordPress/WordPress/commit/8484c7babb6b6ee951f83babea656a294157665d
- */
-require_once file_exists( ABSPATH . 'wp-includes/class-wpdb.php' )
-    ? ABSPATH . 'wp-includes/class-wpdb.php'
-    : ABSPATH . 'wp-includes/wp-db.php';
+require_once ABSPATH . 'wp-includes/class-wpdb.php';
 
 // Override the PHPMailer.
 global $phpmailer;

--- a/includes/core-phpunit/includes/install.php
+++ b/includes/core-phpunit/includes/install.php
@@ -40,7 +40,16 @@ tests_add_filter( 'wp_die_handler', '_wp_die_handler_filter_exit' );
 require_once ABSPATH . 'wp-settings.php';
 
 require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-require_once ABSPATH . 'wp-includes/class-wpdb.php';
+
+/**
+ * File was renamed in WordPress 6.1.
+ *
+ * @see https://core.trac.wordpress.org/ticket/56268
+ * @see https://github.com/WordPress/WordPress/commit/8484c7babb6b6ee951f83babea656a294157665d
+ */
+require_once file_exists( ABSPATH . 'wp-includes/class-wpdb.php' )
+    ? ABSPATH . 'wp-includes/class-wpdb.php'
+    : ABSPATH . 'wp-includes/wp-db.php';
 
 // Override the PHPMailer.
 global $phpmailer;

--- a/includes/core-phpunit/includes/testcase-rest-post-type-controller.php
+++ b/includes/core-phpunit/includes/testcase-rest-post-type-controller.php
@@ -109,8 +109,10 @@ abstract class WPRestPostTypeControllerTestCase extends WPRestControllerTestCase
 		// Check filtered values.
 		if ( post_type_supports( $post->post_type, 'title' ) ) {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
+			add_filter( 'private_title_format', array( $this, 'protected_title_format' ) );
 			$this->assertSame( get_the_title( $post->ID ), $data['title']['rendered'] );
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
+			remove_filter( 'private_title_format', array( $this, 'protected_title_format' ) );
 			if ( 'edit' === $context ) {
 				$this->assertSame( $post->post_title, $data['title']['raw'] );
 			} else {

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -23,7 +23,8 @@ modules:
                 X_WPBROWSER_REQUEST: 1
                 X_TEST_REQUEST: 1
                 X_APM_REQUEST: 1
-            connect_timeout: 3
+            connect_timeout: 3.0
+            timeout: 3.0
         lucatume\WPBrowser\Module\WPDb:
             dsn: '%WORDPRESS_DB_DSN%'
             user: %WORDPRESS_DB_USER%


### PR DESCRIPTION
WordPress 6.1 renamed `wp-includes/wp-db.php` to `wp-includes/class-wpdb.php`, WP Browser looks only for `wp-includes/class-wpdb.php`. This PR checks does it exist and otherwise uses the older file. This allows testing older versions of WordPress.

```
$ codecept run wpunit

Codeception PHP Testing Framework v4.2.2 https://helpukrainewin.org
Powered by PHPUnit 9.6.20 by Sebastian Bergmann and contributors.
PHP Warning:  require_once(/Users/brian.henry/Sites/my-plugin/wordpress/wp-includes/class-wpdb.php): Failed to open stream: No such file or directory in /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/includes/core-phpunit/includes/install.php on line 43
PHP Stack trace:
PHP   1. {main}() /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/includes/core-phpunit/includes/install.php:0
PHP Fatal error:  Uncaught Error: Failed opening required '/Users/brian.henry/Sites/my-plugin/wordpress/wp-includes/class-wpdb.php' (include_path='.:/opt/homebrew/Cellar/php@8.0/8.0.30_3/share/php@8.0/pear') in /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/includes/core-phpunit/includes/install.php:43
Stack trace:
#0 {main}
  thrown in /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/includes/core-phpunit/includes/install.php on line 43
PHP Fatal error:  Uncaught Codeception\Exception\ModuleException: lucatume\WPBrowser\Module\WPLoader: WordPress bootstrap failed.
 in /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/src/Module/WPLoader.php:1033
Stack trace:
#0 [internal function]: lucatume\WPBrowser\Module\WPLoader->lucatume\WPBrowser\Module\{closure}('', 8)
#1 {main}
  thrown in /Users/brian.henry/Sites/my-plugin/vendor/lucatume/wp-browser/src/Module/WPLoader.php on line 1033
Script codecept run wpunit handling the test event returned with error code 255
```

* https://core.trac.wordpress.org/ticket/56268
* https://github.com/WordPress/WordPress/commit/8484c7babb6b6ee951f83babea656a294157665d