### PR TITLE
v4 fix 744

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## Added
+
+- Support for PHPUnit 10 and 11.
+- The `MysqlServerController` extension.
+
 ## [4.2.5] 2024-06-26;
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Support for PHPUnit 10 and 11.
 - The `MysqlServerController` extension.
 
+### Fixed
+
+- Ensure the `WPLoader` module will initialize correctly when used in `loadOnly` mode not using the `EventDispatcherBridge` extension.
+
 ## [4.2.5] 2024-06-26;
 
 ### Changed

--- a/src/WordPress/LoadSandbox.php
+++ b/src/WordPress/LoadSandbox.php
@@ -69,6 +69,7 @@ class LoadSandbox
         if (did_action('wp_loaded') >= 1) {
             return true;
         }
+        $reason = 'action wp_loaded not fired.';
 
         if (count($this->redirects) > 0
             && $this->redirects[0][1] === 302
@@ -101,7 +102,7 @@ class LoadSandbox
         }
 
         // We do not know what happened, throw and try to be helpful.
-        throw InstallationException::becauseWordPressFailedToLoad($bodyContent);
+        throw InstallationException::becauseWordPressFailedToLoad($bodyContent ?: $reason);
     }
 
     public function logRedirection(string $location, int $status): string

--- a/tests/_support/Fork.php
+++ b/tests/_support/Fork.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace lucatume\WPBrowser\Tests\Traits;
+
+use lucatume\WPBrowser\Opis\Closure\SerializableClosure;
+use lucatume\WPBrowser\Process\SerializableThrowable;
+
+/**
+ * Class Fork.
+ *
+ * @since TBD
+ *
+ * @package lucatume\WPBrowser\Tests;
+ */
+class Fork
+{
+    const DEFAULT_TERMINATOR = '__WPBROWSER_SEPARATOR__';
+    private \Closure $callback;
+    private bool $quiet = false;
+    /**
+     * @var int<0, max>
+     */
+    private int $ipcSocketChunkSize = 2048;
+    private string $terminator = self::DEFAULT_TERMINATOR;
+
+    public static function executeClosure(
+        \Closure $callback,
+        bool $quiet = false,
+        int $ipcSocketChunkSize = 2048,
+        string $terminator = self::DEFAULT_TERMINATOR
+    ): mixed {
+        return (new self($callback))
+            ->setQuiet($quiet)
+            ->setIpcSocketChunkSize($ipcSocketChunkSize)
+            ->setTerminator($terminator)
+            ->execute();
+    }
+
+    public function __construct(\Closure $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function setQuiet(bool $quiet): self
+    {
+        $this->quiet = $quiet;
+        return $this;
+    }
+
+    public function execute(): mixed
+    {
+        if (!(function_exists('pcntl_fork') && function_exists('posix_kill'))) {
+            throw new \RuntimeException('pcntl and posix extensions missing.');
+        }
+
+        $sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+        if ($sockets === false) {
+            throw new \RuntimeException('Failed to create socket pair');
+        }
+
+        /** @var array{0: resource, 1: resource} $sockets */
+
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            throw new \RuntimeException('Failed to fork');
+        }
+
+
+        if ($pid === 0) {
+            $this->executeFork($sockets);
+        }
+
+        return $this->executeMain($pid, $sockets);
+    }
+
+    public function setIpcSocketChunkSize(int $ipcSocketChunkSize): self
+    {
+        if ($ipcSocketChunkSize < 0) {
+            throw new \InvalidArgumentException('ipcSocketChunkSize must be a positive integer');
+        }
+
+        $this->ipcSocketChunkSize = $ipcSocketChunkSize;
+        return $this;
+    }
+
+    public function setTerminator(string $terminator): self
+    {
+        $this->terminator = $terminator;
+        return $this;
+    }
+
+    /**
+     * @param array{0: resource, 1: resource} $sockets
+     */
+    private function executeFork(array $sockets): void
+    {
+        fclose($sockets[1]);
+        $ipcSocket = $sockets[0];
+        $pid = getmypid();
+        $didWriteTerminator = false;
+        $terminator = $this->terminator;
+
+        if ($pid === false) {
+            die('Failed to get pid');
+        }
+
+        if ($this->quiet) {
+            fclose(STDOUT);
+            fclose(STDERR);
+        }
+
+        register_shutdown_function(static function () use ($pid, $ipcSocket, &$didWriteTerminator, $terminator) {
+            if (!$didWriteTerminator) {
+                fwrite($ipcSocket, $terminator);
+                $didWriteTerminator = true;
+            }
+            fclose($ipcSocket);
+            /** @noinspection PhpComposerExtensionStubsInspection */
+            posix_kill($pid, 9 /* SIGKILL */);
+        });
+
+        try {
+            $result = ($this->callback)();
+            $resultClosure = new SerializableClosure(static function () use ($result) {
+                return $result;
+            });
+            $resultPayload = serialize($resultClosure);
+        } catch (\Throwable $throwable) {
+            $resultPayload = serialize(new SerializableThrowable($throwable));
+        } finally {
+            if (!isset($resultPayload)) {
+                // Something went wrong.
+                fwrite($ipcSocket, serialize(null));
+                fwrite($ipcSocket, $this->terminator);
+                $didWriteTerminator = true;
+                /** @noinspection PhpComposerExtensionStubsInspection */
+                posix_kill($pid, 9 /* SIGKILL */);
+            }
+        }
+
+        $offset = 0;
+        while (true) {
+            $chunk = substr($resultPayload, $offset, $this->ipcSocketChunkSize);
+
+            if ($chunk === '') {
+                break;
+            }
+
+            fwrite($ipcSocket, $chunk);
+            $offset += $this->ipcSocketChunkSize;
+        }
+        fwrite($ipcSocket, $this->terminator);
+        $didWriteTerminator = true;
+        fclose($ipcSocket);
+
+        // Kill the child process now with a signal that will not run shutdown handlers.
+        /** @noinspection PhpComposerExtensionStubsInspection */
+        posix_kill($pid, 9 /* SIGKILL */);
+    }
+
+    /**
+     * @param array{0: resource, 1: resource} $sockets
+     * @throws \Throwable
+     */
+    private function executeMain(int $pid, array $sockets): mixed
+    {
+        fclose($sockets[0]);
+        $resultPayload = '';
+
+        /** @noinspection PhpComposerExtensionStubsInspection */
+        while (pcntl_wait($status, 1 /* WNOHANG */) <= 0) {
+            $chunk = fread($sockets[1], $this->ipcSocketChunkSize);
+            $resultPayload .= $chunk;
+        }
+
+        while (!str_ends_with($resultPayload, $this->terminator)) {
+            $chunk = fread($sockets[1], $this->ipcSocketChunkSize);
+            $resultPayload .= $chunk;
+        }
+
+        fclose($sockets[1]);
+
+        if (str_ends_with($resultPayload, $this->terminator)) {
+            $resultPayload = substr($resultPayload, 0, -strlen($this->terminator));
+        }
+
+        try {
+            /** @var SerializableClosure|SerializableThrowable $unserializedPayload */
+            $unserializedPayload = @unserialize($resultPayload);
+            $result = $unserializedPayload instanceof SerializableThrowable ?
+                $unserializedPayload->getThrowable() : $unserializedPayload->getClosure()();
+        } catch (\Throwable $t) {
+            $result = $resultPayload;
+        }
+
+        if ($result instanceof \Throwable) {
+            throw $result;
+        }
+
+        /** @noinspection PhpComposerExtensionStubsInspection */
+        posix_kill($pid, 9 /* SIGKILL */);
+
+        return $result;
+    }
+}

--- a/tests/unit/lucatume/WPBrowser/Module/WPLoaderLoadOnlyTest.php
+++ b/tests/unit/lucatume/WPBrowser/Module/WPLoaderLoadOnlyTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace lucatume\WPBrowser\Module;
+
+use Codeception\Lib\Di;
+use Codeception\Lib\ModuleContainer;
+use Codeception\Test\Unit;
+use lucatume\WPBrowser\Tests\Traits\Fork;
+use lucatume\WPBrowser\Tests\Traits\TmpFilesCleanup;
+use lucatume\WPBrowser\Utils\Env;
+use lucatume\WPBrowser\Utils\Filesystem as FS;
+
+class WPLoaderLoadOnlyTest extends Unit
+{
+    use TmpFilesCleanup;
+
+    private function makeMockWordPressInstallation(): array
+    {
+        $dbUser = Env::get('WORDPRESS_DB_USER');
+        $dbPassword = Env::get('WORDPRESS_DB_PASSWORD');
+        $dbLocalhostPort = Env::get('WORDPRESS_DB_LOCALHOST_PORT');
+        $dbName = Env::get('WORDPRESS_DB_NAME');
+        $wpRootFolder = FS::tmpDir('wploader_', [
+            'wp-includes' => [
+                'version.php' => <<< PHP
+                <?php
+                \$wp_version = '6.5';
+                \$wp_db_version = 57155;
+                \$tinymce_version = '49110-20201110';
+                \$required_php_version = '7.0.0';
+                \$required_mysql_version = '5.5.5';
+                PHP
+            ],
+            'wp-config.php' => <<< PHP
+            <?php
+            define('DB_NAME', '$dbName');
+            define('DB_USER', '$dbUser');
+            define('DB_PASSWORD', '$dbPassword');
+            define('DB_HOST', '127.0.0.1:$dbLocalhostPort');
+            define('DB_CHARSET', 'utf8');
+            define('DB_COLLATE', '');
+            global \$table_prefix;
+            \$table_prefix = 'wp_';
+            define('AUTH_KEY', 'auth-key-salt');
+            define('SECURE_AUTH_KEY', 'secure-auth-key-salt');
+            define('LOGGED_IN_KEY', 'logged-in-key-salt');
+            define('NONCE_KEY', 'nonce-key-salt');
+            define('AUTH_SALT', 'auth-salt');
+            define('SECURE_AUTH_SALT', 'secure-auth-salt');
+            define('LOGGED_IN_SALT', 'logged-in-salt');
+            define('NONCE_SALT', 'nonce-salt');
+            PHP,
+            'wp-settings.php' => '<?php',
+            'wp-load.php' => '<?php do_action("wp_loaded");',
+        ]);
+        $dbUrl = sprintf(
+            'mysql://%s:%s@127.0.0.1:%d/%s',
+            $dbUser,
+            $dbPassword,
+            $dbLocalhostPort,
+            $dbName
+        );
+
+        return [$wpRootFolder, $dbUrl];
+    }
+
+    public function testWillLoadWordPressInBeforeSuiteWhenLoadOnlyIsTrue(): void
+    {
+        [$wpRootFolder, $dbUrl] = $this->makeMockWordPressInstallation();
+        $moduleContainer = new ModuleContainer(new Di(), []);
+        $module = new WPLoader($moduleContainer, [
+            'dbUrl' => $dbUrl,
+            'wpRootFolder' => $wpRootFolder,
+            'loadOnly' => true,
+        ]);
+
+        Fork::executeClosure(function () use ($module) {
+            // WordPress' functions are stubbed by wordpress-stubs in unit tests: override them to do something.
+            $did_actions = [];
+            uopz_set_return('do_action', static function ($action) use (&$did_actions) {
+                $did_actions[$action] = true;
+            }, true);
+            uopz_set_return('did_action', static function ($action) use (&$did_actions) {
+                return isset($did_actions[$action]);
+            }, true);
+            // Partial mocking the function that would load WordPress.
+            uopz_set_return(WPLoader::class, 'installAndBootstrapInstallation', function () {
+                $this->fail('The WPLoader::installAndBootstrapInstallation method should not be called');
+            }, true);
+
+            $module->_initialize();
+
+            $this->assertFalse($module->_didLoadWordPress());
+
+            $module->_beforeSuite();
+
+            $this->assertTrue($module->_didLoadWordPress());
+        });
+    }
+
+    public function testWillLoadWordPressInInitializeWhenLoadOnlyIsFalse(): void
+    {
+        [$wpRootFolder, $dbUrl] = $this->makeMockWordPressInstallation();
+        $moduleContainer = new ModuleContainer(new Di(), []);
+        $module = new WPLoader($moduleContainer, [
+            'dbUrl' => $dbUrl,
+            'wpRootFolder' => $wpRootFolder,
+            'loadOnly' => false,
+        ]);
+
+        Fork::executeClosure(function () use ($module) {
+            // WordPress' functions are stubbed by wordpress-stubs in unit tests: override them to do something.
+            $did_actions = [];
+            uopz_set_return('do_action', static function ($action) use (&$did_actions) {
+                $did_actions[$action] = true;
+            }, true);
+            uopz_set_return('did_action', static function ($action) use (&$did_actions) {
+                return isset($did_actions[$action]);
+            }, true);
+            // Partial mocking the function that would load WordPress.
+            uopz_set_return(WPLoader::class, 'installAndBootstrapInstallation', function () {
+                return true;
+            }, true);
+
+            $module->_initialize();
+
+            $this->assertTrue($module->_didLoadWordPress());
+
+            $module->_beforeSuite();
+
+            $this->assertTrue($module->_didLoadWordPress());
+        });
+    }
+}


### PR DESCRIPTION
fixes #744

Change the code of the `WPLoader` module to load WordPress, whether the
`loadOnly` flag is set to `true` or `false`, in the `_beforeSuite`
method.

This removes the need, for the module, to rely on the dispatching,
subscribing and need to do so, to the main Codeception system through
the Codeception event dispatcher.

Kudos to @lxbdr for the proposed solution.