### PR TITLE
Fix factory() return type in `WPTestCase`, so IDE autocompletion works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## Fixed
+
+- Set proper factory() return type in `WPTestCase` class, so IDE autocompletion works (thanks @defunctl).
+
 ## [4.3.3] 2024-09-11;
 
 ## Fixed

--- a/src/TestCase/WPTestCase.php
+++ b/src/TestCase/WPTestCase.php
@@ -18,7 +18,7 @@ use PHPUnit\Runner\Version as PHPUnitVersion;
 /**
  * @method static commit_transaction()
  * @method static delete_user($user_id)
- * @method static factory()
+ * @method \WP_UnitTest_Factory factory()
  * @method static flush_cache()
  * @method static forceTicket($ticket)
  * @method static get_called_class()


### PR DESCRIPTION
Now your IDE should auto complete `$this->factory()->`.

![image](https://github.com/user-attachments/assets/9d3822db-d2a3-43d0-801c-8df45fd1c777)
