### PR TITLE
Improve error & debug messages for Codeception early exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Changed
+
+- Improve `LoadSandbox` errol and messaging (used by the `WPLoader` module when `loadOnly: true`) around Codeception early exits. (thanks @andronocean)
+
 ## [4.3.4] 2024-09-13;
 
 ## Fixed

--- a/config/typos.toml
+++ b/config/typos.toml
@@ -12,3 +12,4 @@ ignore-hidden = false
 [default.extend-words]
 # To handle the hipster default blog content about bike messengers gettin' caught in the rain.
 "gettin" = "gettin"
+"Automattic" = "Automattic"

--- a/includes/airplane-mode/README.md
+++ b/includes/airplane-mode/README.md
@@ -10,7 +10,7 @@ Airplane Mode
 * [Mark Jaquith](https://github.com/markjaquith)
 
 ## About
-Control loading of external files when developing locally. WP loads certain external files (fonts, Gravatar, etc.) and makes external HTTP calls. This isn't usually an issue, unless you're working in an evironment without a web connection. This plugin removes/unhooks those actions to reduce load time and avoid errors due to missing files.
+Control loading of external files when developing locally. WP loads certain external files (fonts, Gravatar, etc.) and makes external HTTP calls. This isn't usually an issue, unless you're working in an environment without a web connection. This plugin removes/unhooks those actions to reduce load time and avoid errors due to missing files.
 
 ## Current Actions
 * removes external JS and CSS files from loading

--- a/src/WordPress/InstallationException.php
+++ b/src/WordPress/InstallationException.php
@@ -43,6 +43,7 @@ class InstallationException extends Exception
     public const SQLITE_PLUGIN_NOT_FOUND = 37;
     public const DB_DROPIN_ALREADY_EXISTS = 38;
     public const WORDPRESS_NOT_FOUND = 39;
+    public const COMMAND_DID_NOT_FINISH_PROPERLY = 40;
 
     public static function becauseWordPressFailedToLoad(string $bodyContent): self
     {
@@ -70,5 +71,13 @@ class InstallationException extends Exception
         }
 
         return new self('WordPress multisite (sub-folder) is not installed.', self::MULTISITE_SUBFOLDER_NOT_INSTALLED);
+    }
+
+    public static function becauseCodeceptionCommandDidNotFinish(): self
+    {
+        return new self(
+            "Codeception `run` command did not finish properly; WordPress exited early prior to wp_loaded.\n",
+            self::COMMAND_DID_NOT_FINISH_PROPERLY
+        );
     }
 }

--- a/src/WordPress/InstallationException.php
+++ b/src/WordPress/InstallationException.php
@@ -76,8 +76,9 @@ class InstallationException extends Exception
     public static function becauseCodeceptionCommandDidNotFinish(): self
     {
         return new self(
-            "Codeception `run` command did not finish properly; WordPress exited early during sandbox installation. "
-            ."A plugin, theme, or WP-CLI package may have exited before the wp_loaded action could run.",
+            "The current Codeception command did not finish properly. WordPress exited early while loading. "
+            ."A plugin, theme, or WP-CLI package may have exited before the wp_loaded action could be fired. " .
+            "If there is error output above, it may provide clues.",
             self::COMMAND_DID_NOT_FINISH_PROPERLY
         );
     }

--- a/src/WordPress/InstallationException.php
+++ b/src/WordPress/InstallationException.php
@@ -76,7 +76,8 @@ class InstallationException extends Exception
     public static function becauseCodeceptionCommandDidNotFinish(): self
     {
         return new self(
-            "Codeception `run` command did not finish properly; WordPress exited early prior to wp_loaded.\n",
+            "Codeception `run` command did not finish properly; WordPress exited early during sandbox installation. "
+            ."A plugin, theme, or WP-CLI package may have exited before the wp_loaded action could run.",
             self::COMMAND_DID_NOT_FINISH_PROPERLY
         );
     }

--- a/src/WordPress/LoadSandbox.php
+++ b/src/WordPress/LoadSandbox.php
@@ -125,7 +125,8 @@ class LoadSandbox
 
         if ($bodyContent === 'COMMAND DID NOT FINISH PROPERLY.') {
             // We got here from \Codeception\Subscriber\ErrorHandler::shutdownHandler().
-            // We'll try to provide some clues to the user by adding some debug output.
+            // We'll try to provide some clues to the user in the exception message.
+            codecept_debug('Codeception error: ' . $bodyContent . ' Check logs for details.');
             throw InstallationException::becauseCodeceptionCommandDidNotFinish();
         }
 

--- a/src/WordPress/LoadSandbox.php
+++ b/src/WordPress/LoadSandbox.php
@@ -127,7 +127,7 @@ class LoadSandbox
             // we got here from \Codeception\Subscriber\ErrorHandler::shutdownHandler()
             codecept_debug('Codeception error: ' .$bodyContent);
             codecept_debug(
-                'DEBUG: Something caused WordPress to exit early. If there is output above, it may provide clues. '
+                'DEBUG: Something caused WordPress to exit early. If there is error output above, it may provide clues. '
                 .'(For instance, a WP-CLI package mistakenly attempting to handle the `codecept run` command.)'
             );
             throw InstallationException::becauseCodeceptionCommandDidNotFinish();

--- a/src/WordPress/LoadSandbox.php
+++ b/src/WordPress/LoadSandbox.php
@@ -123,6 +123,16 @@ class LoadSandbox
             }
         }
 
+        if ($bodyContent === 'COMMAND DID NOT FINISH PROPERLY.') {
+            // we got here from \Codeception\Subscriber\ErrorHandler::shutdownHandler()
+            codecept_debug('Codeception error: ' .$bodyContent);
+            codecept_debug(
+                'DEBUG: Something caused WordPress to exit early. If there is output above, it may provide clues. '
+                .'(For instance, a WP-CLI package mistakenly attempting to handle the `codecept run` command.)'
+            );
+            throw InstallationException::becauseCodeceptionCommandDidNotFinish();
+        }
+
         // We do not know what happened, throw and try to be helpful.
         throw InstallationException::becauseWordPressFailedToLoad($bodyContent ?: $reason);
     }

--- a/src/WordPress/LoadSandbox.php
+++ b/src/WordPress/LoadSandbox.php
@@ -124,12 +124,8 @@ class LoadSandbox
         }
 
         if ($bodyContent === 'COMMAND DID NOT FINISH PROPERLY.') {
-            // we got here from \Codeception\Subscriber\ErrorHandler::shutdownHandler()
-            codecept_debug('Codeception error: ' .$bodyContent);
-            codecept_debug(
-                'DEBUG: Something caused WordPress to exit early. If there is error output above, it may provide clues. '
-                .'(For instance, a WP-CLI package mistakenly attempting to handle the `codecept run` command.)'
-            );
+            // We got here from \Codeception\Subscriber\ErrorHandler::shutdownHandler().
+            // We'll try to provide some clues to the user by adding some debug output.
             throw InstallationException::becauseCodeceptionCommandDidNotFinish();
         }
 


### PR DESCRIPTION
This provides a better debug message and error log when Codeception's ErrorHandler exits early with `COMMAND DID NOT FINISH PROPERLY.` (This is the improvement I mentioned in #753 ... better late than never!)

## Background:

There are a lot of ways execution can stop before WordPress has fully loaded through `/wp-load.php`. `LoadSandbox` already tries to address some of these specifically in the `obCallback` method — like a missing database, a plugin throwing an uncaught exception. **Another scenario is when a call to `exit()` occurs without an uncaught exception or error.** In that situation, Codeception runs its `\Codeception\Subscriber\ErrorHandler->shutdownHandler()` method ([source code](https://github.com/Codeception/Codeception/blob/3d7a135b76f29eba80917db17ef5653fb1c4f885/src/Codeception/Subscriber/ErrorHandler.php#L139)). That method echoes `COMMAND DID NOT FINISH PROPERLY.` and then ` exit(125)`.

Wp-browser's behavior in this situation has been to shutdown silently on the command line, and log a rather unhelpful message: `WordPress failed to load for the following reason: cOMMAND DID NOT FINISH PROPERLY`. This leads to rather arduous step-by-step debugging to track down the source.

(In case it helps anyone who finds this or can spur further improvement: my own impetus for fixing this was trying to use wp-browser on a site using the [Acorn](https://roots.io/acorn/) framework from Roots, which adds its own WP-CLI commands. Its logic checks whether it is running in the console, which is `true` during `codecept run`, and then improperly tries to resolve and handle the `run` command. When it cannot find its own matching command, it exits and thereby triggers Codeception's shutdown handler.)

## What I've done:
This adds a condition to the `LoadSandbox::obCallback` method to check for the Codeception shutdown output. If the output is found, a more specific exception message is thrown, and a clearer message printed to the console when `codecept run` is used with the `--debug` option.

I've tried to add a unit test for the new behavior, but I confess that I'm stuck: the test output shows the functionality is working correctly, but the exception is not getting properly caught by PhpUnit.  It's a tricky thing to test. I modeled it after some of the existing tests in that class, but I think there's something about the `LoopIsolation->assertInIsolation()` method they use that I don't understand. Feedback would be welcomed, or the test can be taken out if it's unneeded.

## Alternatives or possibilities
`LoadSandbox->load()` already sets its own error handler and `wp_die` handler. Maybe it could go further and register a shutdown handler as well to handle the process more cleanly? Given the difficulty of tracing exits, keeping track internally of which actions are reached in the WP loading lifecycle and printing that in debug logs could also be very helpful.

I'm also wondering if it would be appropriate for LoadSandbox to set the `APP_RUNNING_IN_CONSOLE` environment variable to `false` during the sandbox installation. This was how I resolved the problem with Acorn in my own code. Laravel (and thus Acorn and its packages) uses this to control routing to CLI or HTTP handlers. It's a bit implementation-specific, but it could save someone else some trouble.
