### PR TITLE
Use fallback for `$_composer_autoload_path`

### DIFF
--- a/config/typos.toml
+++ b/config/typos.toml
@@ -13,3 +13,4 @@ ignore-hidden = false
 # To handle the hipster default blog content about bike messengers gettin' caught in the rain.
 "gettin" = "gettin"
 "Automattic" = "Automattic"
+"Symplify" = "Symplify"

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace lucatume\WPBrowser\Utils;
 
+use Codeception\Codecept;
 use JsonException;
 use lucatume\WPBrowser\Adapters\Symfony\Component\Process\Process;
 use lucatume\WPBrowser\Exceptions\RuntimeException;
@@ -37,14 +38,13 @@ class Composer
          */
         global $_composer_autoload_path;
         if (isset($_composer_autoload_path)) {
-            $autoload_path = $_composer_autoload_path;
-        } elseif (is_dir(codecept_root_dir('vendor'))) {
-            $autoload_path = codecept_root_dir('vendor') . DIRECTORY_SEPARATOR . 'autoload.php';
+            $autoloadPath = $_composer_autoload_path;
         } else {
-            // vendor-dir was renamed, try our best to find the right directory based on where wp-browser is installed
-            $autoload_path = dirname(__FILE__, 5) . DIRECTORY_SEPARATOR . 'autoload.php';
+            // we use the Codecept class to find the location of Composer's vendor-dir, even if a project has renamed it
+            $vendorDir = dirname((string)(new \ReflectionClass(Codecept::class))->getFilename(), 5);
+            $autoloadPath = $vendorDir . DIRECTORY_SEPARATOR . 'autoload.php';
         }
-        return realpath($autoload_path) ?: $autoload_path;
+        return realpath($autoloadPath) ?: $autoloadPath;
     }
 
     public static function binDir(?string $path = null): string

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -30,8 +30,21 @@ class Composer
 
     public static function autoloadPath(): string
     {
+        /**
+         * if $_composer_autoload_path is undefined, fall back to vendor/autoload.php in the parent project's directory.
+         *
+         * @link https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary
+         */
         global $_composer_autoload_path;
-        return realpath($_composer_autoload_path) ?: $_composer_autoload_path;
+        if (isset($_composer_autoload_path)) {
+            $autoload_path = $_composer_autoload_path;
+        } elseif (is_dir(codecept_root_dir('vendor'))) {
+            $autoload_path = codecept_root_dir('vendor') . DIRECTORY_SEPARATOR . 'autoload.php';
+        } else {
+            // vendor-dir was renamed, try our best to find the right directory based on where wp-browser is installed
+            $autoload_path = dirname(__FILE__, 5) . DIRECTORY_SEPARATOR . 'autoload.php';
+        }
+        return realpath($autoload_path) ?: $autoload_path;
     }
 
     public static function binDir(?string $path = null): string

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -32,7 +32,7 @@ class Composer
     public static function autoloadPath(): string
     {
         /**
-         * if $_composer_autoload_path is undefined, fall back to vendor/autoload.php in the parent project's directory.
+         * If `$_composer_autoload_path` is undefined, fall back to `vendor/autoload.php` in the parent project's directory.
          *
          * @link https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary
          */
@@ -40,7 +40,7 @@ class Composer
         if (isset($_composer_autoload_path)) {
             $autoloadPath = $_composer_autoload_path;
         } else {
-            // we use the Codecept class to find the location of Composer's vendor-dir, even if a project has renamed it
+            // We use the Codecept class to find the location of Composer's vendor-dir, even if a project has renamed it.
             $vendorDir = dirname((string)(new \ReflectionClass(Codecept::class))->getFilename(), 5);
             $autoloadPath = $vendorDir . DIRECTORY_SEPARATOR . 'autoload.php';
         }

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -32,7 +32,8 @@ class Composer
     public static function autoloadPath(): string
     {
         /**
-         * If `$_composer_autoload_path` is undefined, fall back to `vendor/autoload.php` in the parent project's directory.
+         * If `$_composer_autoload_path` is undefined, fall back to `vendor/autoload.php`
+         * in the parent project's directory.
          *
          * @link https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary
          */
@@ -40,7 +41,7 @@ class Composer
         if (isset($_composer_autoload_path)) {
             $autoloadPath = $_composer_autoload_path;
         } else {
-            // We use the Codecept class to find the location of Composer's vendor-dir, even if a project has renamed it.
+            // We use the Codecept class to find the location of Composer's vendor-dir.
             $vendorDir = dirname((string)(new \ReflectionClass(Codecept::class))->getFilename(), 5);
             $autoloadPath = $vendorDir . DIRECTORY_SEPARATOR . 'autoload.php';
         }

--- a/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
+++ b/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
@@ -225,8 +225,8 @@ class ComposerTest extends \Codeception\Test\Unit
      */
     public function static_autoload_path_should_return_global_composer_autoload_path(): void
     {
+        // Ensure that it's set for this test.
         global $_composer_autoload_path;
-        // ensure that it's set for this test
         $_composer_autoload_path = codecept_root_dir() . 'vendor/autoload.php';
 
         $this->assertSame($_composer_autoload_path, Composer::autoloadPath() );
@@ -240,7 +240,6 @@ class ComposerTest extends \Codeception\Test\Unit
      */
     public function static_autoload_path_should_use_fallback(): void
     {
-        global $_composer_autoload_path;
         // clear value to enable fallback
         unset($GLOBALS['_composer_autoload_path']);
 

--- a/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
+++ b/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
@@ -233,7 +233,7 @@ class ComposerTest extends \Codeception\Test\Unit
     }
 
     /**
-     * The `autoloadPath` static method should return a best-guess fallback if the global `$_composer_autoload_path` is undefined
+     * The `autoloadPath` static method should find the autoload.php file itself if the global `$_composer_autoload_path` is undefined
      *
      * @test
      * @backupGlobals enabled
@@ -248,35 +248,5 @@ class ComposerTest extends \Codeception\Test\Unit
 
         $this->assertSame(codecept_root_dir() . 'vendor/autoload.php', $autoloadPath );
         $this->assertFileExists( $autoloadPath );
-    }
-
-    /**
-     * The `autoloadPath` static method should still return a best-guess fallback for `$_composer_autoload_path`
-     * if Composer's vendor-dir was renamed.
-     *
-     * @test
-     * @backupGlobals enabled
-     */
-    public function static_autoload_path_should_use_fallback_if_vendor_dir_renamed_or_missing(): void
-    {
-        global $_composer_autoload_path;
-        // clear value to enable fallback
-        unset($GLOBALS['_composer_autoload_path']);
-        // pretend that wp-browser's own vendor dir does not exist
-        $this->setFunctionReturn('is_dir', false );
-
-        // The method has to find the renamed vendor-dir by directory traversal.
-        // i.e. if wp-browser is installed in `project/pkgs/lucatume/wp-browser`, find the `project/pkgs` dir.
-        // Let's figure out how far it has to go:
-        $mockVendorDir = dirname(codecept_root_dir(), 2);
-        $pathToClass = (new \ReflectionClass(Composer::class))->getFileName();
-        $relPathToVendorDir = substr($pathToClass, strlen($mockVendorDir));
-
-        $this->assertSame(5,
-            // counting directory levels
-            substr_count($relPathToVendorDir, '/'),
-            "The method is hardcoded to look 5 levels up for the parent project's vendor-dir. If this test fails, the class has moved."
-        );
-        $this->assertSame( dirname( $pathToClass, 5 ) . '/autoload.php', Composer::autoloadPath() );
     }
 }

--- a/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
+++ b/tests/unit/lucatume/WPBrowser/Utils/ComposerTest.php
@@ -216,4 +216,67 @@ class ComposerTest extends \Codeception\Test\Unit
             $composer->getDecodedContents()
         );
     }
+
+    /**
+     * The `autoloadPath` static method should return `$_composer_autoload_path` if it is defined
+     *
+     * @test
+     * @backupGlobals enabled
+     */
+    public function static_autoload_path_should_return_global_composer_autoload_path(): void
+    {
+        global $_composer_autoload_path;
+        // ensure that it's set for this test
+        $_composer_autoload_path = codecept_root_dir() . 'vendor/autoload.php';
+
+        $this->assertSame($_composer_autoload_path, Composer::autoloadPath() );
+    }
+
+    /**
+     * The `autoloadPath` static method should return a best-guess fallback if the global `$_composer_autoload_path` is undefined
+     *
+     * @test
+     * @backupGlobals enabled
+     */
+    public function static_autoload_path_should_use_fallback(): void
+    {
+        global $_composer_autoload_path;
+        // clear value to enable fallback
+        unset($GLOBALS['_composer_autoload_path']);
+
+        $autoloadPath = Composer::autoloadPath();
+
+        $this->assertSame(codecept_root_dir() . 'vendor/autoload.php', $autoloadPath );
+        $this->assertFileExists( $autoloadPath );
+    }
+
+    /**
+     * The `autoloadPath` static method should still return a best-guess fallback for `$_composer_autoload_path`
+     * if Composer's vendor-dir was renamed.
+     *
+     * @test
+     * @backupGlobals enabled
+     */
+    public function static_autoload_path_should_use_fallback_if_vendor_dir_renamed_or_missing(): void
+    {
+        global $_composer_autoload_path;
+        // clear value to enable fallback
+        unset($GLOBALS['_composer_autoload_path']);
+        // pretend that wp-browser's own vendor dir does not exist
+        $this->setFunctionReturn('is_dir', false );
+
+        // The method has to find the renamed vendor-dir by directory traversal.
+        // i.e. if wp-browser is installed in `project/pkgs/lucatume/wp-browser`, find the `project/pkgs` dir.
+        // Let's figure out how far it has to go:
+        $mockVendorDir = dirname(codecept_root_dir(), 2);
+        $pathToClass = (new \ReflectionClass(Composer::class))->getFileName();
+        $relPathToVendorDir = substr($pathToClass, strlen($mockVendorDir));
+
+        $this->assertSame(5,
+            // counting directory levels
+            substr_count($relPathToVendorDir, '/'),
+            "The method is hardcoded to look 5 levels up for the parent project's vendor-dir. If this test fails, the class has moved."
+        );
+        $this->assertSame( dirname( $pathToClass, 5 ) . '/autoload.php', Composer::autoloadPath() );
+    }
 }


### PR DESCRIPTION
This fixes a bug I discovered where the `lucatume\WPBrowser\Utils\Composer::autoloadPath()` method will throw a `TypeError` if the `$_composer_autoload_path` global is undefined. The previous code passed the global to `realpath()` without checking if it actually exist.

Apparently `$_composer_autoload_path` can be undefined in various binary contexts — I stumbled across this when trying to use PhpStorm's test runner on test classes & methods that use `#[RunTestsInSeparateProcesses]` and the `IsolationSupport` extension.

[Therefore, Composer recommends having a fallback](https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-autoloader-from-a-binary). (Moreover, without one, the method signature may be incorrect and usages like the `vendorDir()` method will fail if they expect a string.)

I created a fallback condition that first looks for `vendor` in the same directory as `codeception.yml`. If that directory is not found (perhaps the parent project [has customized Composer's `vendor-dir`](https://getcomposer.org/doc/06-config.md#vendor-dir)), it guesses what the autoload path _ought_ to be by walking up directories to where wp-browser should be installed.

I have not changed the original behavior of always returning a string, even if `realpath()` complains that the file does not exist.

Unit tests  for various scenarios are included. Obviously they have to manipulate the global, so I've used `@backupGlobals enabled`, which appears to be sufficient.