### PR TITLE
v4 - locate WPFilesystem module with or without leading slash

### DIFF
--- a/src/Module/WPDb.php
+++ b/src/Module/WPDb.php
@@ -3405,8 +3405,11 @@ class WPDb extends Db
     protected function getWpFilesystemModule(): WPFilesystem
     {
         try {
+            // Support both a prefixed and not prefixed module name.
             /** @var WPFilesystem $fs */
-            $fs = $this->getModule('\\' . WPFilesystem::class);
+            $fs = $this->hasModule('\\' . WPFilesystem::class)
+                ? $this->getModule('\\' . WPFilesystem::class)
+                : $this->getModule(WPFilesystem::class);
 
             return $fs;
         } catch (ModuleException) {


### PR DESCRIPTION
This updates the `getWpFilesystemModule` method of the `WPDb` class to look for the `WPFilesystem` module with or without a leading slash.

Fixes issue #761 