### PR TITLE
fix(PidBasedController) check PID maps to running process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## Fixed
+
+- Check the PID file for the PHP built-in server, MySQL and Chromedriver controllers to make sure the PID maps to an actually running process.
+
 ## [4.3.9] 2024-11-29;
 
 ## Changed

--- a/src/Extension/BuiltInServerController.php
+++ b/src/Extension/BuiltInServerController.php
@@ -19,7 +19,7 @@ class BuiltInServerController extends ServiceExtension
     {
         $pidFile = $this->getPidFile();
 
-        if (is_file($pidFile)) {
+        if ($this->isProcessRunning($pidFile)) {
             $output->writeln('PHP built-in server already running.');
             return;
         }

--- a/src/Extension/ChromeDriverController.php
+++ b/src/Extension/ChromeDriverController.php
@@ -20,7 +20,7 @@ class ChromeDriverController extends ServiceExtension
     {
         $pidFile = $this->getPidFile();
 
-        if (is_file($pidFile)) {
+        if ($this->isProcessRunning($pidFile)) {
             $output->writeln('ChromeDriver already running.');
 
             return;

--- a/src/Extension/MysqlServerController.php
+++ b/src/Extension/MysqlServerController.php
@@ -20,7 +20,7 @@ class MysqlServerController extends ServiceExtension
     {
         $pidFile = $this->getPidFile();
 
-        if (is_file($pidFile)) {
+        if ($this->isProcessRunning($pidFile)) {
             $output->writeln('MySQL server already running.');
 
             return;

--- a/tests/unit/lucatume/WPBrowser/Extension/PidBasedControllerTest.php
+++ b/tests/unit/lucatume/WPBrowser/Extension/PidBasedControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Unit\lucatume\WPBrowser\Extension;
+
+use lucatume\WPBrowser\Extension\PidBasedController;
+use lucatume\WPBrowser\Exceptions\RuntimeException;
+use Symfony\Component\Process\Process;
+
+class PidBasedControllerTest extends \Codeception\Test\Unit
+{
+    public function test_isProcessRunning_on_posix():void{
+        $testClass = new class {
+            use PidBasedController;
+
+            public function openIsProcessRunning(string $pidFile):bool{
+                return $this->isProcessRunning($pidFile);
+            }
+        };
+        $hash = md5(microtime());
+        $pidFile = sys_get_temp_dir()."/test-{$hash}.pid";
+        $pid = posix_getpid();
+        if(!file_put_contents($pidFile,$pid)){
+            $this->fail('Could not write pid to file '.$pidFile);
+        }
+
+        $this->assertTrue($testClass->openIsProcessRunning($pidFile));
+        $this->assertFileExists($pidFile);
+    }
+
+    public function test_isProcessRunning_returns_false_if_pid_file_not_exists():void{
+        $testClass = new class {
+            use PidBasedController;
+
+            public function openIsProcessRunning(string $pidFile):bool{
+                return $this->isProcessRunning($pidFile);
+            }
+        };
+        $pid = posix_getpid();
+
+        $this->assertFalse($testClass->openIsProcessRunning(__DIR__ .'/test.pid'));
+    }
+
+    public function test_isProcessRunning_throws_if_pid_file_cannot_be_read():void{
+        $testClass = new class {
+            use PidBasedController;
+
+            public function openIsProcessRunning(string $pidFile):bool{
+                return $this->isProcessRunning($pidFile);
+            }
+        };
+        $pid = posix_getpid();
+        $hash = md5(microtime());
+        $pidFile = sys_get_temp_dir()."/test-{$hash}.pid";
+        $pid = posix_getpid();
+        if(!file_put_contents($pidFile,$pid)){
+            $this->fail('Could not write pid to file '.$pidFile);
+        }
+        // Change the file mode to not be readable by the current user.
+        chmod($pidFile,0000);
+
+        $this->assertFalse($testClass->openIsProcessRunning($pidFile));
+    }
+
+    public function test_isProcessRunning_returns_false_if_process_is_not_running():void{
+        $testClass = new class {
+            use PidBasedController;
+
+            public function openIsProcessRunning(string $pidFile):bool{
+                return $this->isProcessRunning($pidFile);
+            }
+        };
+        $hash = md5(microtime());
+        $pidFile = sys_get_temp_dir()."/test-{$hash}.pid";
+        $process = new Process(['echo', '23']);
+        $process->start();
+        $pid = $process->getPid();
+        $process->wait();
+        if(!file_put_contents($pidFile,$pid)){
+            $this->fail('Could not write pid to file '.$pidFile);
+        }
+
+        $this->assertFalse($testClass->openIsProcessRunning($pidFile));
+        $this->assertFileNotExists($pidFile);
+    }
+}


### PR DESCRIPTION
This fixes the issue where one of the managed processes (Chromedriver,
PHP built-in server or MySQL server) would be killed by the system or
user outside of wp-browser control leaving an orphaned PID file pointing
at a no-more-running process.
