### PR TITLE
fix(WPCLI) restore allow-root support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- Restored support for the `allow-root` configuration parameter in the `WPCLI` module.
+
 ## [4.5.3] 2025-05-08;
 
 ### Fixed

--- a/docs/modules/WPCLI.md
+++ b/docs/modules/WPCLI.md
@@ -47,6 +47,7 @@ This module should be with [Cest][2] and [Cept][3] test cases.
 * `packages-dir` - the directory to use to store the packages downloaded by the `wp package` command. Equivalent to
   setting the `WP_CLI_PACKAGES_DIR` environment variable.
 * `bin` - the path to a custom WP-CLI binary.
+* `allow-root` - a boolean value to indicate if the `wp` command should be run with the `--allow-root` flag. Equivalent to the `--allow-root` option of the `wp` command. This is useful when running wp-cli commands as the root user.
 
 The following is an example of the module configuration to run WPCLI commands on the `/var/wordpress` directory:
 

--- a/src/Module/WPCLI.php
+++ b/src/Module/WPCLI.php
@@ -42,6 +42,7 @@ class WPCLI extends Module
         'no-color' => true,
         'debug' => true,
         'quiet' => true,
+        'allow-root' => true,
     ];
     /**
      * @var array<string>
@@ -77,7 +78,8 @@ class WPCLI extends Module
      *    config-path?: string,
      *    custom-shell?: string,
      *    packages-dir?: string,
-     *    bin?: string
+     *    bin?: string,
+     *    allow-root?: bool
      * }
      */
     protected array $config = [
@@ -132,7 +134,8 @@ class WPCLI extends Module
          *    config-path?: string,
          *    custom-shell?: string,
          *    packages-dir?: string,
-         *    bin?: string
+         *    bin?: string,
+         *    allow-root?: bool
          * } $config
          */
         $config = $this->config;
@@ -501,7 +504,7 @@ class WPCLI extends Module
             }
         }
 
-        foreach (['skip-plugins', 'skip-themes', 'skip-packages', 'debug', 'quiet', 'color', 'no-color'] as $boolKey) {
+        foreach (['skip-plugins', 'skip-themes', 'skip-packages', 'debug', 'quiet', 'color', 'no-color', 'allow-root'] as $boolKey) {
             if (empty($this->config[$boolKey])) {
                 unset($this->config[$boolKey]);
             } else {

--- a/src/Module/WPCLI.php
+++ b/src/Module/WPCLI.php
@@ -504,7 +504,17 @@ class WPCLI extends Module
             }
         }
 
-        foreach (['skip-plugins', 'skip-themes', 'skip-packages', 'debug', 'quiet', 'color', 'no-color', 'allow-root'] as $boolKey) {
+        foreach ([
+                'skip-plugins',
+                'skip-themes',
+                'skip-packages',
+                'debug',
+                'quiet',
+                'color',
+                'no-color',
+                'allow-root'
+            ] as $boolKey
+        ) {
             if (empty($this->config[$boolKey])) {
                 unset($this->config[$boolKey]);
             } else {

--- a/tests/unit/lucatume/WPBrowser/Module/WPCLITest.php
+++ b/tests/unit/lucatume/WPBrowser/Module/WPCLITest.php
@@ -848,6 +848,36 @@ class WPCLITest extends Unit
     }
 
     /**
+     * It should allow configuring wp-cli to run with allow-root
+     *
+     * @test
+     */
+    public function should_allow_configuring_wp_cli_to_run_with_allow_root(): void
+    {
+        $wpcli = $this->module([
+            'path' => self::$installation->getWpRootDir(),
+            'allow-root' => true
+        ]);
+
+        $wpcli->cli(['core', 'version']);
+
+        $commandLine = $wpcli->grabLastCliProcess()->getCommandLine();
+        $wpCliPhar = CliProcess::getWpCliPharPathname();
+
+        $expected = implode(
+            ' ',
+            array_map('escapeshellarg', [
+                PHP_BINARY,
+                $wpCliPhar,
+                '--allow-root',
+                'core',
+                'version'
+            ])
+        );
+        $this->assertEquals($expected, $commandLine);
+    }
+
+    /**
      * It should inherit env from current session when env not specified
      *
      * @test


### PR DESCRIPTION
Restore support for the `allow-root` configuration parameter in the `WPCLI` module removed, by mistake, in version 4 refactoring.
