### PR TITLE
Use `WPLoader::$bootstrapOutput` in exception

### DIFF
--- a/src/Module/WPLoader.php
+++ b/src/Module/WPLoader.php
@@ -1096,7 +1096,7 @@ class WPLoader extends Module
 
                 // The inclusion of the test bootstrap file, or a WordPress file included by it, called `exit` or `die`.
                 // Jump in on the flow to provide a meaningful message to the user.
-                throw new ModuleException(__CLASS__, 'WordPress bootstrap failed.' . PHP_EOL . $buffer);
+                throw new ModuleException(__CLASS__, 'WordPress bootstrap failed.' . PHP_EOL . ($buffer ?: $this->bootstrapOutput) );
             }
 
             $buffer = trim($buffer);

--- a/src/Module/WPLoader.php
+++ b/src/Module/WPLoader.php
@@ -1096,7 +1096,7 @@ class WPLoader extends Module
 
                 // The inclusion of the test bootstrap file, or a WordPress file included by it, called `exit` or `die`.
                 // Jump in on the flow to provide a meaningful message to the user.
-                throw new ModuleException(__CLASS__, 'WordPress bootstrap failed.' . PHP_EOL . ($buffer ?: $this->bootstrapOutput) );
+                throw new ModuleException(__CLASS__, 'WordPress bootstrap failed.' . PHP_EOL . ($buffer ?: $this->bootstrapOutput));
             }
 
             $buffer = trim($buffer);


### PR DESCRIPTION
Before:

```
% codecept run wpunit

Codeception PHP Testing Framework v5.1.2 https://stand-with-ukraine.pp.ua
PHP Fatal error:  Uncaught Codeception\Exception\ModuleException: lucatume\WPBrowser\Module\WPLoader: WordPress bootstrap failed.
 in /Users/brianhenry/Sites/bh-wp-bitcoin-gateway/vendor/lucatume/wp-browser/src/Module/WPLoader.php:1099
Stack trace:
#0 [internal function]: lucatume\WPBrowser\Module\WPLoader->lucatume\WPBrowser\Module\{closure}('', 8)
#1 {main}
  thrown in /Users/brianhenry/Sites/bh-wp-bitcoin-gateway/vendor/lucatume/wp-browser/src/Module/WPLoader.php on line 1099
```

After:

```
% codecept run wpunit

Codeception PHP Testing Framework v5.1.2 https://stand-with-ukraine.pp.ua
PHP Fatal error:  Uncaught Codeception\Exception\ModuleException: lucatume\WPBrowser\Module\WPLoader: WordPress bootstrap failed.

wp_die() called
Message: One or more database tables are unavailable. The database may need to be <a href="maint/repair.php?referrer=is_blog_installed">repaired</a>.
Title: WordPress &rsaquo; Error
Args:
	response: 500
	code: wp_die
	exit: 1
	back_link: 
	link_url: 
	link_text: 
	text_direction: ltr
	charset: UTF-8
	additional_errors: array (
)
 in /Users/brianhenry/Sites/bh-wp-bitcoin-gateway/vendor/lucatume/wp-browser/src/Module/WPLoader.php:1099
Stack trace:
#0 [internal function]: lucatume\WPBrowser\Module\WPLoader->lucatume\WPBrowser\Module\{closure}('', 8)
#1 {main}
  thrown in /Users/brianhenry/Sites/bh-wp-bitcoin-gateway/vendor/lucatume/wp-browser/src/Module/WPLoader.php on line 1099
```