### PR TITLE
v4 fix plugin activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+## [4.5.5] 2025-08-15;
+
 ### Changed
 
 - Better `WPLoader` module output in exceptions (thanks @BrianHenryIE).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- Updated `activatePlugin` and `deactivatePlugin` methods in `WPBrowser` and `WPWebDriver` modules to use WordPress 6.5+ compatible selectors
+
 ## [4.5.5] 2025-08-15;
 
 ### Changed

--- a/src/Module/WPBrowser.php
+++ b/src/Module/WPBrowser.php
@@ -85,10 +85,8 @@ class WPBrowser extends PhpBrowser
     public function activatePlugin(string|array $pluginSlug): void
     {
         foreach ((array)$pluginSlug as $plugin) {
-            $this->checkOption('//*[@data-slug="' . $plugin . '"]/th/input');
+            $this->click('a#activate-' . $plugin);
         }
-        $this->selectOption('action', 'activate-selected');
-        $this->click("#doaction");
     }
 
     /**
@@ -113,9 +111,7 @@ class WPBrowser extends PhpBrowser
     public function deactivatePlugin(string|array $pluginSlug): void
     {
         foreach ((array) $pluginSlug as $plugin) {
-            $this->checkOption('//*[@data-slug="' . $plugin . '"]/th/input');
+            $this->click('a#deactivate-' . $plugin);
         }
-        $this->selectOption('action', 'deactivate-selected');
-        $this->click('#doaction');
     }
 }

--- a/src/Module/WPLoader.php
+++ b/src/Module/WPLoader.php
@@ -1096,7 +1096,10 @@ class WPLoader extends Module
 
                 // The inclusion of the test bootstrap file, or a WordPress file included by it, called `exit` or `die`.
                 // Jump in on the flow to provide a meaningful message to the user.
-                throw new ModuleException(__CLASS__, 'WordPress bootstrap failed.' . PHP_EOL . ($buffer ?: $this->bootstrapOutput));
+                throw new ModuleException(
+                    __CLASS__,
+                    'WordPress bootstrap failed.' . PHP_EOL . ($buffer ?: $this->bootstrapOutput)
+                );
             }
 
             $buffer = trim($buffer);

--- a/src/Module/WPWebDriver.php
+++ b/src/Module/WPWebDriver.php
@@ -220,13 +220,10 @@ class WPWebDriver extends WebDriver
     public function deactivatePlugin(string|array $pluginSlug): void
     {
         foreach ((array)$pluginSlug as $plugin) {
-            $option = '//*[@data-slug="' . $plugin . '"]/th/input';
-            $this->scrollTo($option, 0, -40);
-            $this->checkOption($option);
+            $selector = 'a#deactivate-' . $plugin;
+            $this->scrollTo($selector, 0, -40);
+            $this->click($selector);
         }
-        $this->scrollTo('select[name="action"]', 0, -40);
-        $this->selectOption('action', 'deactivate-selected');
-        $this->click("#doaction");
     }
 
     /**
@@ -255,12 +252,9 @@ class WPWebDriver extends WebDriver
     {
         $plugins = (array)$pluginSlug;
         foreach ($plugins as $plugin) {
-            $option = '//*[@data-slug="' . $plugin . '"]/th/input';
-            $this->scrollTo($option, 0, -40);
-            $this->checkOption($option);
+            $selector = 'a#activate-' . $plugin;
+            $this->scrollTo($selector, 0, -40);
+            $this->click($selector);
         }
-        $this->scrollTo('select[name="action"]', 0, -40);
-        $this->selectOption('action', 'activate-selected');
-        $this->click("#doaction");
     }
 }


### PR DESCRIPTION
Update the selectors used in the `WPBrowser` and `WPWebDriver` modules to activate and deactivate plugins to use the new selectors introduced in version `6.5` of WordPress.
