### PR TITLE
v4 - fix StubClassFactory optional parameter detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- `StubClassFactory` issue where mocking of internal classes would  incorrectly detect optional constructor parameters.
+
 ## [4.5.13] 2026-02-18;
 
 ### Changed

--- a/tests/_support/StubClassFactory.php
+++ b/tests/_support/StubClassFactory.php
@@ -127,7 +127,7 @@ class StubClassFactory
         $mockClassName = $classBasename . '_' . substr(md5(microtime()), 0, 8);
         $constructorStringDump = (new ReflectionMethod($class, '__construct'))->__toString();
         preg_match_all(
-            '/Parameter #\\d+ \\[ <(?:optional|required)> (?<parameter>.*) ]/u',
+            '/Parameter #\\d+ \\[ <(?<kind>optional|required)> (?<parameter>.*) ]/u',
             $constructorStringDump,
             $matches
         );
@@ -135,9 +135,15 @@ class StubClassFactory
         if (!empty($matches)) {
             $constructorParams = implode(
                 ', ',
-                array_map(static function (string $p): string {
-                    return str_replace('or NULL', '', $p);
-                }, $matches['parameter'])
+                array_map(static function (string $p, string $kind): string {
+                    $p = str_replace('or NULL', '', $p);
+                    // Internal PHP classes may not include default values for optional parameters
+                    // in their reflection dump. Add a default to avoid "too few arguments" errors.
+                    if ($kind === 'optional' && strpos($p, '=') === false) {
+                        $p .= ' = null';
+                    }
+                    return $p;
+                }, $matches['parameter'], $matches['kind'])
             );
         }
 


### PR DESCRIPTION
PHP 7.4 reflection dumps for internal classes (like PharData) may omit
default values for optional parameters, causing generated mock constructors
to require all arguments. Add `= null` for optional params missing defaults.
