### PR TITLE
fix(SQLiteDatabase): hex-encode multi-line values in dump (#802)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,9 +33,10 @@ concurrency:
 
 env:
   # Pin the WordPress version used to set up the test site. WordPress 7.0's admin
-  # bootstrap fatals (uksort on a null $menu) during wp-browser's install, so the
-  # suite is pinned to the last 6.8.x stable. See #804; remove once the installer supports 7.0.
-  WORDPRESS_VERSION: '6.8.5'
+  # bootstrap fatals (uksort on a null $menu) during wp-browser's install, and the
+  # current WooCommerce test plugin requires WP >= 6.9, so the suite is pinned to the
+  # latest 6.9.x. See #804; remove once the installer supports 7.0.
+  WORDPRESS_VERSION: '6.9.4'
 
 jobs:
   test_on_84:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,12 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+env:
+  # Pin the WordPress version used to set up the test site. WordPress 7.0's admin
+  # bootstrap fatals (uksort on a null $menu) during wp-browser's install, so the
+  # suite is pinned to the last 6.8.x stable. Remove once the installer supports 7.0.
+  WORDPRESS_VERSION: '6.8.5'
+
 jobs:
   test_on_84:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ concurrency:
 env:
   # Pin the WordPress version used to set up the test site. WordPress 7.0's admin
   # bootstrap fatals (uksort on a null $menu) during wp-browser's install, so the
-  # suite is pinned to the last 6.8.x stable. Remove once the installer supports 7.0.
+  # suite is pinned to the last 6.8.x stable. See #804; remove once the installer supports 7.0.
   WORDPRESS_VERSION: '6.8.5'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Drop the bundled `includes/opis/closure/` library and its `lucatume\WPBrowser\Opis\Closure\` PSR-4 autoload entry.
 
+### Fixed
+
+- `wp:db:export` from a SQLite installation no longer produces a non-importable dump: values are hex-encoded instead of a `char(10)` concatenation chain that overflowed SQLite's expression-depth limit on values with many newlines (#802).
+
 ### Breaking change
 
 - The `lucatume\WPBrowser\Opis\Closure\*` namespace is no longer autoloaded. None of its classes were part of the documented public API but the namespace was reachable via PSR-4; any consumer that imported or extended them must migrate to `lucatume\WPBrowser\Utils\PackedClosure`.

--- a/bin/setup-wp.php
+++ b/bin/setup-wp.php
@@ -42,8 +42,9 @@ $installation = new Installation($wpRootDir);
 
 echo "Checking WordPress installation in $wpRootDir ...\n";
 if ($installation->getState() instanceof EmptyDir) {
-    echo "Scaffolding WordPress in $wpRootDir ...\n";
-    $installation = Installation::scaffold($wpRootDir);
+    $wpVersion = getenv('WORDPRESS_VERSION') ?: 'latest';
+    echo "Scaffolding WordPress ($wpVersion) in $wpRootDir ...\n";
+    $installation = Installation::scaffold($wpRootDir, $wpVersion);
 }
 
 echo "Creating database {$env['WORDPRESS_DB_NAME']} ...\n";

--- a/src/WordPress/Database/SQLiteDatabase.php
+++ b/src/WordPress/Database/SQLiteDatabase.php
@@ -300,10 +300,11 @@ class SQLiteDatabase implements DatabaseInterface
             $sql .= implode(",", $fieldNames) . ") VALUES";
 
             do {
-                foreach ($row as $k => $v) {
-                    $row[$k] = "'" . str_replace("\n", "' || char(10) || '", SQLite3::escapeString($v)) . "'";
+                $values = [];
+                foreach ($row as $v) {
+                    $values[] = $this->quoteValue((string)$v);
                 }
-                $sql .= "\n(" . implode(",", $row) . "),";
+                $sql .= "\n(" . implode(",", $values) . "),";
             } while ($row = $rows->fetchArray(SQLITE3_ASSOC));
 
             $sql = rtrim($sql, ",") . ";\n\n";
@@ -314,6 +315,20 @@ class SQLiteDatabase implements DatabaseInterface
         if (file_put_contents($dumpFilePath, $sql) === false) {
             throw new DbException("Could not write dump file $dumpFilePath.", DbException::FAILED_DUMP);
         }
+    }
+
+    private function quoteValue(string $value): string
+    {
+        // Inlining a value with newlines used to require a `'...' || char(10) || '...'` chain, one
+        // `||` per newline; a value with more than ~1000 newlines overflows SQLite's expression
+        // depth limit and the resulting INSERT cannot be parsed on import. Hex-encoding control
+        // characters (and non-UTF-8 bytes) keeps each value on a single line as one shallow
+        // expression; the CAST keeps TEXT storage affinity so comparisons against text still work.
+        if (preg_match('/[\x00-\x08\x0A-\x1F\x7F]/', $value) === 1 || preg_match('//u', $value) === false) {
+            return "CAST(X'" . bin2hex($value) . "' AS TEXT)";
+        }
+
+        return "'" . SQLite3::escapeString($value) . "'";
     }
 
     public function setEnvVars(): void

--- a/tests/_support/Traits/FastScaffold.php
+++ b/tests/_support/Traits/FastScaffold.php
@@ -24,6 +24,15 @@ trait FastScaffold
 {
     protected function fastScaffold(string $wpRoot, string $version = 'latest'): Installation
     {
+        if ($version === 'latest') {
+            // Stopgap (#804): honor the WORDPRESS_VERSION pin used by CI so tests that scaffold
+            // `latest` avoid WordPress releases that break the installer (e.g. 7.0's multisite install).
+            $pinned = getenv('WORDPRESS_VERSION');
+            if (is_string($pinned) && $pinned !== '' && $pinned !== 'latest') {
+                $version = $pinned;
+            }
+        }
+
         if (!FS::cowCopy(Source::getForVersion($version), $wpRoot)) {
             throw new RuntimeException(sprintf('FastScaffold: could not clone WordPress source into "%s"', $wpRoot));
         }

--- a/tests/unit/Codeception/Template/WpbrowserTest.php
+++ b/tests/unit/Codeception/Template/WpbrowserTest.php
@@ -21,27 +21,9 @@ use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 class WpbrowserTest extends \Codeception\Test\Unit
 {
     use TmpFilesCleanup;
-    use SnapshotAssertions {
-        assertMatchesDirectorySnapshot as private baseAssertMatchesDirectorySnapshot;
-    }
+    use SnapshotAssertions;
     use PhaseTimer;
     use FastScaffold;
-
-    /**
-     * Overrides the trait assertion to normalize the YAML rendering of empty inline maps:
-     * symfony/yaml 6/7 dump an empty map as `{  }`, symfony/yaml 8 (PHP 8.4+) dumps it as `{}`.
-     * Normalizing both sides keeps the scaffold directory snapshots stable across versions.
-     */
-    public function assertMatchesDirectorySnapshot(string $current, ?callable $dataVisitor = null): void
-    {
-        $this->baseAssertMatchesDirectorySnapshot(
-            $current,
-            $dataVisitor ?? static function (string $data, string $expected): array {
-                $normalize = static fn(string $yaml): string => (string)preg_replace('/\{ +\}/', '{}', $yaml);
-                return [$normalize($data), $normalize($expected)];
-            }
-        );
-    }
 
     private function mockComposerBin(string $directory): void
     {
@@ -62,6 +44,15 @@ EOT;
 
     private function replaceRandomPorts(array $expected, array $actual, string $file): array
     {
+        // symfony/yaml 6/7 dump an empty inline map as `{  }`, symfony/yaml 8 (PHP 8.4+) as `{}`;
+        // normalize both so the scaffolded codeception.yml snapshots match across versions.
+        $normalizeEmptyMaps = static fn(array $lines): array => array_map(
+            static fn(string $line): string => (string)preg_replace('/\{ +\}/', '{}', $line),
+            $lines
+        );
+        $expected = $normalizeEmptyMaps($expected);
+        $actual = $normalizeEmptyMaps($actual);
+
         if (!str_ends_with($file, 'tests/.env')) {
             return [$expected, $actual];
         }

--- a/tests/unit/Codeception/Template/WpbrowserTest.php
+++ b/tests/unit/Codeception/Template/WpbrowserTest.php
@@ -21,9 +21,27 @@ use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 class WpbrowserTest extends \Codeception\Test\Unit
 {
     use TmpFilesCleanup;
-    use SnapshotAssertions;
+    use SnapshotAssertions {
+        assertMatchesDirectorySnapshot as private baseAssertMatchesDirectorySnapshot;
+    }
     use PhaseTimer;
     use FastScaffold;
+
+    /**
+     * Overrides the trait assertion to normalize the YAML rendering of empty inline maps:
+     * symfony/yaml 6/7 dump an empty map as `{  }`, symfony/yaml 8 (PHP 8.4+) dumps it as `{}`.
+     * Normalizing both sides keeps the scaffold directory snapshots stable across versions.
+     */
+    public function assertMatchesDirectorySnapshot(string $current, ?callable $dataVisitor = null): void
+    {
+        $this->baseAssertMatchesDirectorySnapshot(
+            $current,
+            $dataVisitor ?? static function (string $data, string $expected): array {
+                $normalize = static fn(string $yaml): string => (string)preg_replace('/\{ +\}/', '{}', $yaml);
+                return [$normalize($data), $normalize($expected)];
+            }
+        );
+    }
 
     private function mockComposerBin(string $directory): void
     {

--- a/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
+++ b/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
@@ -348,6 +348,33 @@ class SqliteDatabaseTest extends \Codeception\Test\Unit
     }
 
     /**
+     * It should export values with more newlines than the SQLite expression depth limit
+     *
+     * @test
+     * @group fast
+     */
+    public function should_export_values_with_many_newlines_into_an_importable_dump(): void
+    {
+        $dump = codecept_data_dir('dump.sqlite');
+        $dir = FS::tmpDir('sqlite_');
+        $db = new SQLiteDatabase($dir, 'db.sqlite');
+        $db->import($dump);
+
+        // SQLite caps expression-tree depth at 1000; a value with more newlines than that
+        // would overflow a `'...' || char(10) || '...'` concatenation chain on import.
+        $manyLines = str_repeat("line\n", 2000);
+        $db->updateOption('big_multiline', $manyLines);
+
+        $dumpFile = tempnam(sys_get_temp_dir(), 'sqlite_');
+        $db->dump($dumpFile);
+
+        $checkDb = new SQLiteDatabase($dir, 'checkdb.sqlite');
+        $checkDb->import($dumpFile);
+
+        $this->assertEquals($manyLines, $checkDb->getOption('big_multiline'));
+    }
+
+    /**
      * It should throw if database dump file cannot be written
      *
      * @test

--- a/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
+++ b/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
@@ -375,6 +375,60 @@ class SqliteDatabaseTest extends \Codeception\Test\Unit
     }
 
     /**
+     * It should round-trip fuzzed values through export, import and export again
+     *
+     * @test
+     * @group fast
+     */
+    public function should_round_trip_fuzzed_values_through_export_import_export(): void
+    {
+        // Fixed seed so any failure reproduces identically. NUL bytes are excluded on purpose:
+        // the ext-sqlite3 reader truncates TEXT at NUL, which is a separate, known limitation.
+        mt_srand(0x5EED);
+        $dir = FS::tmpDir('sqlite_fuzz_');
+
+        for ($iteration = 0; $iteration < 100; $iteration++) {
+            $values = [];
+            for ($id = 1, $count = mt_rand(1, 15); $id <= $count; $id++) {
+                $values[$id] = $this->fuzzValue();
+            }
+
+            $srcDb = new SQLiteDatabase($dir, "src_$iteration.sqlite");
+            $srcDb->query('CREATE TABLE fuzz (id INTEGER PRIMARY KEY, val TEXT NOT NULL)');
+            foreach ($values as $id => $value) {
+                $srcDb->query('INSERT INTO fuzz (id, val) VALUES (:id, :val)', [':id' => $id, ':val' => $value]);
+            }
+
+            $dumpA = "$dir/dump_a_$iteration.sql";
+            $srcDb->dump($dumpA);
+
+            $dstDb = new SQLiteDatabase($dir, "dst_$iteration.sqlite");
+            $dstDb->import($dumpA);
+
+            $dumpB = "$dir/dump_b_$iteration.sql";
+            $dstDb->dump($dumpB);
+
+            // Export/import/export is stable: re-dumping the imported database yields the same SQL.
+            $this->assertSame(
+                file_get_contents($dumpA),
+                file_get_contents($dumpB),
+                "Dump is not idempotent across export/import/export at iteration $iteration."
+            );
+
+            // The data itself survived the round-trip byte-for-byte.
+            $readBack = (new \PDO($dstDb->getDsn()))
+                ->query('SELECT val FROM fuzz ORDER BY id')
+                ->fetchAll(\PDO::FETCH_COLUMN);
+
+            $this->assertSame(
+                array_values($values),
+                $readBack,
+                "Imported values do not match the originals at iteration $iteration."
+            );
+        }
+    }
+
+    /**
      * It should throw if database dump file cannot be written
      *
      * @test
@@ -426,5 +480,70 @@ class SqliteDatabaseTest extends \Codeception\Test\Unit
         $db->updateOption('test', $optionValue);
 
         $this->assertEquals($expectedOptionValue, $db->getOption('test'));
+    }
+
+    private function fuzzValue(): string
+    {
+        switch (mt_rand(0, 8)) {
+            case 0: // Printable ASCII.
+                return $this->randomBytes(mt_rand(0, 80), 0x20, 0x7e);
+            case 1: // Quote and backslash heavy.
+                $parts = ["'", '"', '\\', "''", "\\'", '`', '%', '_'];
+                $value = '';
+                for ($i = 0, $n = mt_rand(1, 30); $i < $n; $i++) {
+                    $value .= $parts[mt_rand(0, count($parts) - 1)] . $this->randomBytes(mt_rand(0, 4), 0x61, 0x7a);
+                }
+                return $value;
+            case 2: // More newlines than the SQLite expression-depth limit.
+                $value = '';
+                for ($i = 0, $n = mt_rand(1, 1500); $i < $n; $i++) {
+                    $value .= 'l' . mt_rand(0, 9) . "\n";
+                }
+                return $value;
+            case 3: // CR / LF / tab mix.
+                $whitespace = ["\n", "\r", "\r\n", "\t", ' '];
+                $value = '';
+                for ($i = 0, $n = mt_rand(1, 200); $i < $n; $i++) {
+                    $value .= $whitespace[mt_rand(0, count($whitespace) - 1)] . $this->randomBytes(mt_rand(0, 3), 0x61, 0x7a);
+                }
+                return $value;
+            case 4: // Control characters, no NUL.
+                return $this->randomBytes(mt_rand(0, 64), 0x01, 0x1f);
+            case 5: // Multibyte UTF-8.
+                $pool = ['é', 'ñ', 'ü', '中', '文', 'Ω', 'λ', '—', '„', '🎉', '😀', 'ζ'];
+                $value = '';
+                for ($i = 0, $n = mt_rand(0, 40); $i < $n; $i++) {
+                    $value .= $pool[mt_rand(0, count($pool) - 1)];
+                }
+                return $value;
+            case 6: // Arbitrary binary, no NUL; usually invalid UTF-8.
+                return $this->randomBytes(mt_rand(0, 96), 0x01, 0xff);
+            case 7: // SQL tokens and the encoder's own markers.
+                $pool = [
+                    "' || char(10) || '",
+                    "CAST(X'6162' AS TEXT)",
+                    "'); DROP TABLE fuzz; --",
+                    ";\nSELECT 1;",
+                    "PRAGMA foreign_keys = OFF;",
+                    'a:1:{s:3:"key";s:5:"value";}',
+                    'N;',
+                ];
+                $value = '';
+                for ($i = 0, $n = mt_rand(1, 6); $i < $n; $i++) {
+                    $value .= $pool[mt_rand(0, count($pool) - 1)];
+                }
+                return $value;
+            default: // Empty or whitespace.
+                return mt_rand(0, 1) === 0 ? '' : str_repeat(" \t", mt_rand(0, 12));
+        }
+    }
+
+    private function randomBytes(int $length, int $min, int $max): string
+    {
+        $bytes = '';
+        for ($i = 0; $i < $length; $i++) {
+            $bytes .= chr(mt_rand($min, $max));
+        }
+        return $bytes;
     }
 }


### PR DESCRIPTION
## Problem

`wp:db:export` from a SQLite installation produced a dump that could not be re-imported (#802).

`SQLiteDatabase::dump()` encoded newlines in values as a `'...' || char(10) || '...'` concatenation chain, one `||` per newline. SQLite caps expression-tree depth at `SQLITE_MAX_EXPR_DEPTH` (1000). Any cell with more than ~1000 newlines (e.g. a `_site_transient_feed_*` RSS cache WordPress fills in at runtime) overflowed that limit, so the generated `INSERT` failed to parse on import:

```
Parse error: Expression tree is too large (maximum depth 1000)
```

A fresh install dump works (no large multi-line values yet); the failure surfaces after the site runs and you re-export to update your suite dump.

## Fix

Encode values containing control characters or non-UTF-8 bytes as `CAST(X'<hex>' AS TEXT)` instead of a concatenation chain:

- single shallow expression per value, so depth is constant regardless of newline count;
- no newline/quote/semicolon inside the token, so `import()`'s splitter and the WPDb/Codeception loader are unaffected;
- `CAST(... AS TEXT)` keeps TEXT storage affinity, so text comparisons still work;
- plain values keep the readable `'...'` quoted form.

Dump-only and backward compatible: old `char(10)` dumps still import as-is.

## Tests

- `should_export_values_with_many_newlines_into_an_importable_dump`: 2000-newline value, dump -> import round-trip. Fails on `master` with the depth error.
- `should_round_trip_fuzzed_values_through_export_import_export`: seeded fuzz over export/import/export with randomized values (newlines past the depth limit, CR/LF, quotes, control chars, multibyte UTF-8, arbitrary non-NUL binary, and the encoder's own markers); asserts the two dumps are byte-identical and the data reads back unchanged. Verified RED on `master`, GREEN with the fix.
- `SqliteDatabaseTest`: 28 pass, 4 pre-existing skips, 258 assertions.
- End-to-end: regenerated a 2.1 MB `dump.sql` via `wp:db:export`, then `codecept run EndToEnd` passes loading it through the WPDb populate path.

`cs-fix` / `cs` / `typos` clean. PHPStan could not run locally (bundled phpstan.phar crashes on this PHP 8.5 dev build, independent of the change).

## Known limitation (out of scope)

Values with an embedded NUL byte still do not round-trip: `dump()` reads via `SQLite3::fetchArray`, which truncates TEXT at the first NUL. This is pre-existing and unrelated to the depth bug; the fuzz alphabet excludes NUL for that reason.