### PR TITLE
fix: support WordPress 7.0 install (uksort on null $menu)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,13 +31,6 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-env:
-  # Pin the WordPress version used to set up the test site. WordPress 7.0's admin
-  # bootstrap fatals (uksort on a null $menu) during wp-browser's install, and the
-  # current WooCommerce test plugin requires WP >= 6.9, so the suite is pinned to the
-  # latest 6.9.x. See #804; remove once the installer supports 7.0.
-  WORDPRESS_VERSION: '6.9.4'
-
 jobs:
   test_on_84:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `wp:db:export` from a SQLite installation no longer produces a non-importable dump: values are hex-encoded instead of a `char(10)` concatenation chain that overflowed SQLite's expression-depth limit on values with many newlines (#802).
+- The installer no longer fatals when setting up WordPress 7.0: `FileRequest` binds the `$menu`, `$submenu` and `$compat` admin-menu globals to the global scope before loading the target file, so WordPress 7.0's admin bootstrap does not run `uksort()` on a null `$menu` (#804).
 
 ### Breaking change
 

--- a/src/WordPress/FileRequests/FileRequest.php
+++ b/src/WordPress/FileRequests/FileRequest.php
@@ -158,6 +158,16 @@ abstract class FileRequest
             $preLoadClosure($this->targetFile);
         }
 
+        // The target file is required in this method scope, not the global one. WordPress'
+        // `wp-admin/menu.php` builds `$menu`/`$submenu`/`$compat` in the including scope with no
+        // `global` declaration, while `wp-admin/includes/menu.php` (as of WP 7.0) declares them
+        // `global` before `uksort($menu, ...)`. Without binding them to the global scope here, that
+        // rebind hits a null global and fatals on PHP 8. Only these three are bound on purpose:
+        // the menu builder's `$_wp_*_nopriv` bookkeeping must stay scoped to this require so
+        // `user_can_access_admin_page()` keeps reading empty globals and does not deny the request
+        // (the current user is set after load, not during it).
+        global $menu, $submenu, $compat;
+
         require $this->targetFile;
 
         $returnValues = [];

--- a/tests/unit/lucatume/WPBrowser/Extension/PidBasedControllerTest.php
+++ b/tests/unit/lucatume/WPBrowser/Extension/PidBasedControllerTest.php
@@ -75,10 +75,13 @@ class PidBasedControllerTest extends \Codeception\Test\Unit
         };
         $hash = md5(microtime());
         $pidFile = sys_get_temp_dir()."/test-{$hash}.pid";
-        $process = new Process(['echo', '23']);
+        // A short-lived process like `echo` can exit before getPid() reads its PID, leaving $pid
+        // null. Use a long-running process so the PID is captured reliably, then stop it so the
+        // PID refers to a process that is no longer running.
+        $process = new Process(['sleep', '30']);
         $process->start();
         $pid = $process->getPid();
-        $process->wait();
+        $process->stop(0);
         if(!file_put_contents($pidFile,$pid)){
             $this->fail('Could not write pid to file '.$pidFile);
         }

--- a/tests/unit/lucatume/WPBrowser/WordPress/FileRequests/FileRequestTest.php
+++ b/tests/unit/lucatume/WPBrowser/WordPress/FileRequests/FileRequestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Unit\lucatume\WPBrowser\WordPress\FileRequests;
+
+use Codeception\Test\Unit;
+use lucatume\WPBrowser\Tests\Traits\Fork;
+use lucatume\WPBrowser\Tests\Traits\TmpFilesCleanup;
+use lucatume\WPBrowser\Utils\Filesystem as FS;
+use lucatume\WPBrowser\WordPress\FileRequests\FileGetRequest;
+
+class FileRequestTest extends Unit
+{
+    use TmpFilesCleanup;
+
+    /**
+     * The target file is required inside FileRequest::execute(), a method scope. WordPress admin
+     * entry scripts build `$menu`/`$submenu`/`$compat` in the including scope without a `global`
+     * declaration, while a later include (WP 7.0 `wp-admin/includes/menu.php`) declares them
+     * `global` before `uksort()`. Without the menu globals being bound to the global scope before
+     * the require, that rebind hits an empty global and `uksort(null)` fatals on PHP 8.
+     *
+     * @test
+     */
+    public function it_keeps_admin_menu_globals_global_across_required_includes(): void
+    {
+        $dir = FS::tmpDir('file_request_', [
+            // Mimics wp-admin/admin.php -> wp-admin/menu.php: builds $menu without `global`.
+            'entry.php' => <<<'PHP'
+<?php
+$menu[10] = ['Ten'];
+$menu[2]  = ['Two'];
+require __DIR__ . '/includes.php';
+PHP,
+            // Mimics WP 7.0 wp-admin/includes/menu.php: declares the globals, then sorts.
+            'includes.php' => <<<'PHP'
+<?php
+global $menu, $submenu, $compat;
+uksort($menu, 'strnatcasecmp');
+PHP,
+        ]);
+
+        $request = new FileGetRequest('localhost', '/wp-admin/admin.php', $dir . '/entry.php', ['a' => '1']);
+        $request->addAfterLoadClosure(static fn(): array => array_keys($GLOBALS['menu'] ?? []));
+
+        $result = Fork::executeClosure(static fn(): array => $request->execute());
+
+        $this->assertSame([[2, 10]], $result);
+    }
+}


### PR DESCRIPTION
Closes #804.

## Problem
`FileRequest::execute()` requires the target file in **method scope**, not global scope. WP 7.0's `wp-admin/includes/menu.php` added `global $menu, $submenu, $compat;` before `uksort($menu, ...)`, while `wp-admin/menu.php` builds those vars in the including scope with no `global` declaration. So the build landed method-local, the WP 7.0 declaration rebound to the empty true-global, and `uksort(null)` fataled on PHP 8 during the network install's `wp-admin/admin.php` request. Result: every Test workflow died at the "Setup WordPress" step.

## Fix
Bind `$menu`, `$submenu`, `$compat` to the global scope just before the `require` in `FileRequest::execute()`.

Only these three are bound on purpose. Declaring the broader menu family (the `$_wp_*_nopriv` bookkeeping) made those globals populated too, which flipped `user_can_access_admin_page()` to deny and produced a second fatal (`wp_die: Sorry, you are not allowed to access this page`) — the current user is set *after* the load, not during it. Keeping the nopriv arrays request-scoped preserves the install's existing behavior.

Also removes the `WORDPRESS_VERSION` CI pin so the matrix uses `latest`.

## Verification
- New unit test reproduces the exact `uksort` TypeError through `FileRequest.php` (red), passes after the fix (green).
- End-to-end via the real `setup-wp.php` path: WP 7.0 multisite-subfolder → `Multisite`, WP 7.0 single-site → `Single`, WP 6.8.5 multisite (no regression) → `Multisite`.
- `cs` / `typos` clean; WordPress unit suite shows zero new failures vs. baseline (pre-existing failures are environmental: missing `uopz`, PHP 8.5 deprecations).