### PR TITLE
Fix `wp:db:export` truncating values at NUL bytes on SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Fixed
+
+- `wp:db:export` from a SQLite installation no longer truncates values containing NUL bytes (e.g. serialized objects with protected/private properties): table rows are read with each column cast to `BLOB` so the `SQLite3` extension does not stop at the first NUL byte, and the full value is hex-encoded into the dump.
+
 ## [4.6.0] 2026-06-09;
 
 ### Changed

--- a/src/WordPress/Database/SQLiteDatabase.php
+++ b/src/WordPress/Database/SQLiteDatabase.php
@@ -272,7 +272,25 @@ class SQLiteDatabase implements DatabaseInterface
             }
 
             $sql .= "DROP TABLE IF EXISTS $table[0];\n" . $tableSql . ";\n\n";
-            $rows = $db->query("SELECT * FROM $table[0]");
+
+            $columns = $db->query("PRAGMA table_info($table[0])");
+
+            if ($columns === false) {
+                throw new DbException("Could not read columns from table $table[0].", DbException::FAILED_DUMP);
+            }
+
+            $fieldNames = [];
+            $selectColumns = [];
+
+            while ($column = $columns->fetchArray(SQLITE3_ASSOC)) {
+                $fieldNames[] = "'" . $column["name"] . "'";
+                // Read each column CAST to BLOB: the SQLite3 extension truncates TEXT values at the
+                // first NUL byte on fetch, corrupting serialized data (e.g. objects with protected
+                // properties). BLOB values are returned binary-safe and quoteValue() hex-encodes them.
+                $selectColumns[] = 'CAST("' . $column["name"] . '" AS BLOB) AS "' . $column["name"] . '"';
+            }
+
+            $rows = $db->query("SELECT " . implode(",", $selectColumns) . " FROM $table[0]");
 
             if ($rows === false) {
                 throw new DbException("Could not read rows from table $table[0].", DbException::FAILED_DUMP);
@@ -284,20 +302,7 @@ class SQLiteDatabase implements DatabaseInterface
                 continue;
             }
 
-            $sql .= "INSERT INTO {$table[0]} (";
-            $columns = $db->query("PRAGMA table_info($table[0])");
-
-            if ($columns === false) {
-                throw new DbException("Could not read columns from table $table[0].", DbException::FAILED_DUMP);
-            }
-
-            $fieldNames = [];
-
-            while ($column = $columns->fetchArray(SQLITE3_ASSOC)) {
-                $fieldNames[] = "'" . $column["name"] . "'";
-            }
-
-            $sql .= implode(",", $fieldNames) . ") VALUES";
+            $sql .= "INSERT INTO {$table[0]} (" . implode(",", $fieldNames) . ") VALUES";
 
             do {
                 $values = [];

--- a/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
+++ b/tests/unit/lucatume/WPBrowser/WordPress/Database/SqliteDatabaseTest.php
@@ -241,6 +241,40 @@ class SqliteDatabaseTest extends \Codeception\Test\Unit
     }
 
     /**
+     * It should preserve values containing NUL bytes when dumping
+     *
+     * @test
+     * @group fast
+     */
+    public function should_preserve_nul_bytes_in_values_when_dumping(): void
+    {
+        $dir = FS::tmpDir('sqlite_');
+        $db = new SQLiteDatabase($dir, 'db.sqlite');
+        $db->create();
+        $db->query(
+            'CREATE TABLE wp_options (option_id INTEGER PRIMARY KEY, option_name TEXT NOT NULL,'
+            . ' option_value TEXT NOT NULL, autoload TEXT NOT NULL)'
+        );
+        // PHP serializes protected/private properties with NUL bytes (e.g. "\0*\0name"); the SQLite3
+        // extension truncates TEXT at the first NUL on read, so the dump must not lose the remainder.
+        $value = 'before' . "\0" . 'after-the-nul-must-survive';
+        $db->query(
+            'INSERT INTO wp_options (option_name, option_value, autoload) VALUES (:name, :value, :autoload)',
+            [':name' => 'with_nul', ':value' => $value, ':autoload' => 'yes']
+        );
+
+        $dumpFile = $dir . '/dump.sql';
+        $db->dump($dumpFile);
+
+        $restoreDir = FS::tmpDir('sqlite_');
+        $restored = new SQLiteDatabase($restoreDir, 'db.sqlite');
+        $restored->create();
+        $restored->import($dumpFile);
+
+        $this->assertSame($value, $restored->getOption('with_nul'));
+    }
+
+    /**
      * It should throw if trying to import from non-existing file
      *
      * @test


### PR DESCRIPTION
A dump that loses everything past the first NUL byte.

`wp:db:export` on a SQLite installation silently truncates any column value that contains a NUL byte. The dump looks fine and imports without error, it just quietly drops data. Serialized objects with protected or private properties are the usual casualties, since PHP writes those property names as `\0*\0name` / `\0Class\0name`. WooCommerce's Action Scheduler stores its schedules that way, so a dumped-and-restored site comes back with the `schedule` column cut down to `O:32:"ActionScheduler_IntervalSchedule":5:{s:22:"` and `unserialize()` failing on every row.

## The cause

`SQLiteDatabase::dump()` reads rows with `SELECT * FROM <table>` through the `SQLite3` extension and `fetchArray()`. For a TEXT column the extension returns the bytes up to the first NUL and no further; the rest is gone before it ever reaches `quoteValue()`. So the control-character guard from 4.6 (#802) never gets a chance here: by the time it runs there is no NUL left to detect, and the already-truncated string is written out as a plain quoted literal.

The data at rest is fine; PDO reads it back whole. Only the export path is lossy.

## The fix

Read each column `CAST(... AS BLOB)`. BLOB values come back from `fetchArray()` binary-safe, NUL and all, and the existing `quoteValue()` then hex-encodes them into `CAST(X'..' AS TEXT)` like any other control-character value. The import side is untouched.

## The test

`should_preserve_nul_bytes_in_values_when_dumping` writes a value with a NUL in the middle, dumps, imports into a fresh database and reads it back through `getOption()` (PDO, so binary-safe). On `master` it comes back as `before`; with the fix it round-trips whole.
