### PR TITLE
Add dev:rebuild command, GitHub workflow example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - `init wpbrowser` set up the default-configuration admin user with the email `admin@exmaple.com`; it now uses `admin@example.com` (#807).
+- MySQL server binary download no longer fails with HTTP 403: `dev.mysql.com`'s CDN started blocking the custom user agent, so the downloader now sends a `curl/<version>` user agent that is allowed through (#808).
 
 ## [4.6.1] 2026-06-16;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `dev:rebuild` command to build the `tests/_wordpress` installation used by the default configuration, e.g. on a fresh clone or in CI where it is not committed. Documented the default self-contained setup on GitHub Actions, with an example workflow (#807).
 - `init wpbrowser` records the installed WordPress version in the `WORDPRESS_VERSION` entry of `tests/.env`; `dev:rebuild` reuses it (override with `--wp-version`) so a rebuilt installation matches the version the committed `dump.sql` was generated from (#807).
+- `init wpbrowser` (plugin and theme projects) writes a `tests/_wordpress/.gitignore` so the rebuildable WordPress installation is not committed; restore it with `dev:rebuild` (#807).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased] Unreleased
 
+### Added
+
+- `dev:rebuild` command to build the `tests/_wordpress` installation used by the default configuration, e.g. on a fresh clone or in CI where it is not committed. Documented the default self-contained setup on GitHub Actions, with an example workflow (#807).
+- `init wpbrowser` records the installed WordPress version in the `WORDPRESS_VERSION` entry of `tests/.env`; `dev:rebuild` reuses it (override with `--wp-version`) so a rebuilt installation matches the version the committed `dump.sql` was generated from (#807).
+
+### Fixed
+
+- `init wpbrowser` set up the default-configuration admin user with the email `admin@exmaple.com`; it now uses `admin@example.com` (#807).
+
 ## [4.6.1] 2026-06-16;
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `dev:rebuild` command to build the `tests/_wordpress` installation used by the default configuration, e.g. on a fresh clone or in CI where it is not committed. Documented the default self-contained setup on GitHub Actions, with an example workflow (#807).
 - `init wpbrowser` records the installed WordPress version in the `WORDPRESS_VERSION` entry of `tests/.env`; `dev:rebuild` reuses it (override with `--wp-version`) so a rebuilt installation matches the version the committed `dump.sql` was generated from (#807).
 - `init wpbrowser` (plugin and theme projects) writes a `tests/_wordpress/.gitignore` so the rebuildable WordPress installation is not committed; restore it with `dev:rebuild` (#807).
+- `init wpbrowser` (plugin and theme projects) writes a `tests/Support/Data/.gitignore` with `!dump.sql` so the database fixture is committed even when a global gitignore excludes `*.sql` (#807).
 
 ### Fixed
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -147,6 +147,27 @@ Provides information about the local testing stack managed by
 the [DockerComposeController](extensions.md#dockercomposecontroller), [BuiltInServerController](extensions.md#builtinservercontroller)
 and [ChromeDriverController](extensions.md#chromedrivercontroller) extensions.
 
+### `dev:rebuild`
+
+Enable the command with:
+
+```yaml
+extensions:
+  commands:
+    - "lucatume\\WPBrowser\\Command\\DevRebuild"
+```
+
+Builds the `tests/_wordpress` WordPress installation used by the [default configuration](default-configuration.md):
+it downloads WordPress, configures it to use SQLite and installs it, reproducing what
+`vendor/bin/codecept init wpbrowser` set up the first time. Use it on a fresh clone of a project or on a CI
+runner where `tests/_wordpress` is not committed. It does nothing if the installation already exists; delete
+the directory to rebuild it. The command supports the default SQLite configuration only.
+
+By default it installs the version recorded in the `WORDPRESS_VERSION` entry of `tests/.env` (written by
+`init`), falling back to the latest release. Pass `--wp-version` to override it, e.g.
+`vendor/bin/codecept dev:rebuild --wp-version=6.8.1`. Pin the version to the one your committed `dump.sql`
+was generated from so the rebuilt site matches the database fixture.
+
 ### `wp:db:import`
 
 Enable the command with:

--- a/docs/default-configuration.md
+++ b/docs/default-configuration.md
@@ -63,6 +63,77 @@ exporting the database dump using [the `wp:db:export` command](commands.md#wpdbe
 You can find out about the URL of the site served by the PHP built-in web server by
 running [the `dev:info` command](commands.md#devinfo).
 
+## Version control and continuous integration
+
+The `tests/_wordpress` directory is a full WordPress installation: do not commit it, add it to your
+`.gitignore`. Commit instead the files that describe the environment so it can be rebuilt anywhere:
+
+```
+# .gitignore
+/vendor/
+/tests/_wordpress/
+/tests/_output/
+```
+
+Commit `codeception.yml`, the `tests/*.suite.yml` files, `tests/.env` and the database
+fixture `tests/Support/Data/dump.sql` together with your plugin or theme code and tests.
+
+On a fresh clone, or on a CI runner, rebuild the `tests/_wordpress` installation with a single command:
+
+```bash
+vendor/bin/codecept dev:rebuild
+```
+
+The command downloads WordPress, configures it to use SQLite and installs it in `tests/_wordpress`,
+reproducing what `vendor/bin/codecept init wpbrowser` set up the first time. The database state used by
+the tests comes from the `dump.sql` fixture loaded by [the WPDb module](modules/WPDb.md#configuration), so
+`dev:rebuild` does not touch it.
+
+`init` records the WordPress version it installed in the `WORDPRESS_VERSION` entry of `tests/.env`, and
+`dev:rebuild` reuses it so the rebuilt installation matches the version your `dump.sql` was generated from.
+Commit `tests/.env` to keep the rebuild deterministic; override the version per run with
+`vendor/bin/codecept dev:rebuild --wp-version=6.8.1`.
+
+> If your project was set up before this command existed, add
+> `lucatume\WPBrowser\Command\DevRebuild` to the `extensions.commands` list in your `codeception.yml`.
+
+### Example GitHub Action
+
+This workflow runs the default self-contained configuration on GitHub Actions. The Ubuntu runners ship with
+Chrome already installed, so the only setup steps are installing Composer dependencies, rebuilding the
+WordPress installation and installing the matching Chromedriver:
+
+```yaml
+name: Tests
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Build the WordPress installation
+        run: vendor/bin/codecept dev:rebuild
+
+      - name: Install Chromedriver
+        run: vendor/bin/codecept chromedriver:update --binary "$(which google-chrome)"
+
+      - name: Run tests
+        run: vendor/bin/codecept run
+```
+
+The PHP built-in server and Chromedriver are started automatically when the end-to-end suite runs; you do
+not need a separate `dev:start` step.
+
 ## When not to use the default configuration
 
 The default configuration is the recommended one for most projects, but some projects might require you to use a custom

--- a/docs/default-configuration.md
+++ b/docs/default-configuration.md
@@ -65,18 +65,19 @@ running [the `dev:info` command](commands.md#devinfo).
 
 ## Version control and continuous integration
 
-The `tests/_wordpress` directory is a full WordPress installation: do not commit it, add it to your
-`.gitignore`. Commit instead the files that describe the environment so it can be rebuilt anywhere:
+The `tests/_wordpress` directory is a full WordPress installation: do not commit it. `init wpbrowser`
+writes a `tests/_wordpress/.gitignore` that ignores its contents, so it is never committed and is restored
+with `dev:rebuild`. Ignore the rest of the rebuildable directories in your project `.gitignore` as usual
+(Codeception already ignores `tests/_output`):
 
 ```
 # .gitignore
 /vendor/
-/tests/_wordpress/
-/tests/_output/
 ```
 
-Commit `codeception.yml`, the `tests/*.suite.yml` files, `tests/.env` and the database
-fixture `tests/Support/Data/dump.sql` together with your plugin or theme code and tests.
+Commit the files that describe the environment: `codeception.yml`, the `tests/*.suite.yml` files,
+`tests/.env` and the database fixture `tests/Support/Data/dump.sql`, together with your plugin or theme
+code and tests.
 
 On a fresh clone, or on a CI runner, rebuild the `tests/_wordpress` installation with a single command:
 

--- a/docs/default-configuration.md
+++ b/docs/default-configuration.md
@@ -79,10 +79,19 @@ Commit the files that describe the environment: `codeception.yml`, the `tests/*.
 `tests/.env` and the database fixture `tests/Support/Data/dump.sql`, together with your plugin or theme
 code and tests.
 
-On a fresh clone, or on a CI runner, rebuild the `tests/_wordpress` installation with a single command:
+> If a global gitignore (e.g. `~/.gitignore_global`) excludes `*.sql`, the `dump.sql` fixture will not be
+> committed. `init wpbrowser` writes a `tests/Support/Data/.gitignore` with `!dump.sql` to force it back in;
+> if your project predates that, add `!tests/Support/Data/dump.sql` to your project `.gitignore`.
+
+On a fresh clone, or on a CI runner, install dependencies, rebuild the `tests/_wordpress` installation with
+[the `dev:rebuild` command](commands.md#devrebuild) and install the matching Chromedriver with
+[the `chromedriver:update` command](commands.md#chromedriverupdate):
 
 ```bash
+composer install
 vendor/bin/codecept dev:rebuild
+vendor/bin/codecept chromedriver:update
+vendor/bin/codecept run
 ```
 
 The command downloads WordPress, configures it to use SQLite and installs it in `tests/_wordpress`,

--- a/src/Command/DevRebuild.php
+++ b/src/Command/DevRebuild.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace lucatume\WPBrowser\Command;
+
+use Codeception\CustomCommandInterface;
+use lucatume\WPBrowser\Exceptions\RuntimeException;
+use lucatume\WPBrowser\Extension\BuiltInServerController;
+use lucatume\WPBrowser\Utils\Env;
+use lucatume\WPBrowser\WordPress\Installation;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
+use Throwable;
+
+class DevRebuild extends Command implements CustomCommandInterface
+{
+    use ServiceExtensionsTrait;
+
+    public static function getCommandName(): string
+    {
+        return 'dev:rebuild';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Builds the WordPress installation used by the default configuration ' .
+            '(tests/_wordpress), e.g. on a fresh clone or in CI.';
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'wp-version',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'The WordPress version to install (e.g. "6.8.1"). Defaults to the WORDPRESS_VERSION ' .
+            'environment value, or "latest".'
+        );
+    }
+
+    /**
+     * Resolves the WordPress version to install, in order of precedence: the --wp-version option,
+     * the WORDPRESS_VERSION environment value recorded by `init`, then "latest".
+     */
+    public static function resolveVersion(?string $optionVersion, string|false|null $envVersion): string
+    {
+        if (is_string($optionVersion) && $optionVersion !== '') {
+            return $optionVersion;
+        }
+
+        if (is_string($envVersion) && $envVersion !== '') {
+            return $envVersion;
+        }
+
+        return 'latest';
+    }
+
+    /**
+     * Resolves the WordPress root and SQLite database directory from the BuiltInServerController config.
+     *
+     * @param array<string,mixed> $serverConfig
+     *
+     * @return array{0: string, 1: string, 2: string} [wpRootDir, dataDir, url]
+     */
+    public static function resolveTarget(array $serverConfig, string $rootDir): array
+    {
+        $docRoot = $serverConfig['docroot'] ?? null;
+        $env = $serverConfig['env'] ?? [];
+        $isSqlite = is_array($env)
+            && (($env['DATABASE_TYPE'] ?? null) === 'sqlite' || ($env['DB_ENGINE'] ?? null) === 'sqlite');
+
+        if (!is_string($docRoot) || $docRoot === '' || !$isSqlite) {
+            throw new RuntimeException(
+                'The dev:rebuild command only supports the default SQLite configuration produced by ' .
+                '`vendor/bin/codecept init wpbrowser`. Set up your WordPress installation manually.'
+            );
+        }
+
+        $wpRootDir = rtrim(Path::isAbsolute($docRoot) ? $docRoot : $rootDir . '/' . $docRoot, '/');
+        // The default configuration keeps the SQLite database next to the installation, in a data sub-directory.
+        $dataDir = $wpRootDir . '/data';
+
+        $port = $serverConfig['port'] ?? null;
+        $url = is_numeric($port) ? "http://localhost:$port" : 'http://localhost';
+
+        return [$wpRootDir, $dataDir, $url];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rootDir = rtrim(codecept_root_dir(), '/');
+        $serverConfig = $this->getServiceExtensionConfig(BuiltInServerController::class);
+
+        try {
+            [$wpRootDir, $dataDir, $url] = self::resolveTarget($serverConfig, $rootDir);
+        } catch (RuntimeException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+
+        if (is_file($wpRootDir . '/wp-load.php')) {
+            $output->writeln("WordPress is already installed in <info>$wpRootDir</info>.");
+            $output->writeln('Delete that directory and run this command again to rebuild it.');
+            return 0;
+        }
+
+        $optionVersion = $input->getOption('wp-version');
+        $version = self::resolveVersion(
+            is_string($optionVersion) ? $optionVersion : null,
+            Env::get('WORDPRESS_VERSION')
+        );
+
+        try {
+            $output->writeln("Installing WordPress <info>$version</info> in <info>$wpRootDir</info> ...");
+            Installation::scaffoldWithSqlite($wpRootDir, $dataDir, $url, 'Test', $version);
+        } catch (Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+
+        $output->writeln('<info>WordPress installed.</info>');
+        $output->writeln('The database state is restored from the WPDb dump when tests run.');
+
+        return 0;
+    }
+}

--- a/src/Project/ContentProject.php
+++ b/src/Project/ContentProject.php
@@ -157,6 +157,15 @@ EOT;
         if (!is_file($wpRootDir . '/.gitignore')) {
             file_put_contents($wpRootDir . '/.gitignore', "*\n!.gitignore\n", LOCK_EX);
         }
+
+        // Force the database fixture to be committed even when a global gitignore excludes `*.sql`.
+        $dataDir = $this->workDir . '/' . $dataDirRelativePath;
+        if (!is_file($dataDir . '/.gitignore')) {
+            file_put_contents($dataDir . '/.gitignore', "!dump.sql\n", LOCK_EX);
+        }
+        if (is_file($dataDir . '/.gitkeep')) {
+            unlink($dataDir . '/.gitkeep');
+        }
     }
 
     abstract public function getName(): string;

--- a/src/Project/ContentProject.php
+++ b/src/Project/ContentProject.php
@@ -152,6 +152,11 @@ EOT;
             ['%codecept_root_dir%', 'tests', '_wordpress', 'data', 'db.sqlite']
         );
         $this->testEnvironment->afterSuccess = $this->getAfterSuccessClosure($activated);
+
+        // Keep the rebuildable installation out of version control; it is restored with `dev:rebuild`.
+        if (!is_file($wpRootDir . '/.gitignore')) {
+            file_put_contents($wpRootDir . '/.gitignore', "*\n!.gitignore\n", LOCK_EX);
+        }
     }
 
     abstract public function getName(): string;

--- a/src/Project/ContentProject.php
+++ b/src/Project/ContentProject.php
@@ -6,6 +6,7 @@ use Closure;
 use Codeception\InitTemplate;
 use lucatume\WPBrowser\Command\ChromedriverUpdate;
 use lucatume\WPBrowser\Command\DevInfo;
+use lucatume\WPBrowser\Command\DevRebuild;
 use lucatume\WPBrowser\Command\DevRestart;
 use lucatume\WPBrowser\Command\DevStart;
 use lucatume\WPBrowser\Command\DevStop;
@@ -17,7 +18,6 @@ use lucatume\WPBrowser\Utils\ChromedriverInstaller;
 use lucatume\WPBrowser\Utils\Codeception;
 use lucatume\WPBrowser\Utils\Filesystem as FS;
 use lucatume\WPBrowser\Utils\Random;
-use lucatume\WPBrowser\WordPress\Database\SQLiteDatabase;
 use lucatume\WPBrowser\WordPress\Installation;
 use lucatume\WPBrowser\WordPress\Source;
 use Throwable;
@@ -58,27 +58,17 @@ abstract class ContentProject extends InitTemplate implements ProjectInterface
         $wpRootDir = $this->workDir . '/tests/_wordpress';
         $dataDir = $this->workDir . '/tests/_wordpress/data';
         $dataDirRelativePath = Codeception::dataDir();
-
-        if (!is_dir($dataDir) && !(mkdir($dataDir, 0777, true) && is_dir($dataDir))) {
-            throw new RuntimeException("Could not create WordPress data directory $dataDir.");
-        }
-
-        $db = new SQLiteDatabase('tests/_wordpress/data', 'db.sqlite');
+        $serverLocalhostPort = Random::openLocalhostPort();
 
         $this->sayInfo('Installing WordPress in tests/_wordpress ...');
-        Installation::scaffold($wpRootDir);
-        // Remove the directory used to store the WordPress installation.
-        FS::rrmdir(Source::getWordPressVersionsCacheDir());
-        $installation = new Installation($wpRootDir);
-        $installation->configure($db);
-        $serverLocalhostPort = Random::openLocalhostPort();
-        $installation->install(
+        $installation = Installation::scaffoldWithSqlite(
+            $wpRootDir,
+            $dataDir,
             "http://localhost:$serverLocalhostPort",
-            'admin',
-            'password',
-            'admin@exmaple.com',
             $this->getName() . ' Test'
         );
+        // Remove the directory used to download the WordPress installation.
+        FS::rrmdir(Source::getWordPressVersionsCacheDir());
 
         $this->symlinkProjectInContentDir($wpRootDir);
 
@@ -90,6 +80,10 @@ abstract class ContentProject extends InitTemplate implements ProjectInterface
             throw new RuntimeException('Could not create temporary file to store database dump.');
         }
 
+        $db = $installation->getDb();
+        if ($db === null) {
+            throw new RuntimeException('The WordPress installation has no database after install.');
+        }
         $db->dump($tmpDumpFile);
         FS::mkdirp($this->workDir . '/' . $dataDirRelativePath);
         if (!rename($tmpDumpFile, $this->workDir . '/' . $dataDirRelativePath . '/dump.sql')) {
@@ -114,6 +108,12 @@ abstract class ContentProject extends InitTemplate implements ProjectInterface
 BUILTIN_SERVER_PORT=$serverLocalhostPort
 
 EOT;
+
+        $wpVersion = $installation->getVersion()?->getWpVersion();
+        if ($wpVersion) {
+            $this->testEnvironment->extraEnvFileContents .= "# The WordPress version installed by `init`, "
+                . "reused by the `dev:rebuild` command.\nWORDPRESS_VERSION=$wpVersion\n\n";
+        }
 
         $symlinkerConfig = [ 'wpRootFolder' => '%WORDPRESS_ROOT_DIR%' ];
 
@@ -144,6 +144,7 @@ EOT;
         $this->testEnvironment->customCommands[] = DevStop::class;
         $this->testEnvironment->customCommands[] = DevInfo::class;
         $this->testEnvironment->customCommands[] = DevRestart::class;
+        $this->testEnvironment->customCommands[] = DevRebuild::class;
         $this->testEnvironment->customCommands[] = ChromedriverUpdate::class;
         $this->testEnvironment->wpRootDir = FS::relativePath($this->workDir, $wpRootDir);
         $this->testEnvironment->dbUrl = 'sqlite://' . implode(

--- a/src/Utils/Download.php
+++ b/src/Utils/Download.php
@@ -41,12 +41,9 @@ class Download
         curl_setopt($curlHandle, CURLOPT_TIMEOUT, 120);
         curl_setopt($curlHandle, CURLOPT_FILE, $file);
 
-        // Set the user agent header.
-        curl_setopt(
-            $curlHandle,
-            CURLOPT_USERAGENT,
-            'Mozilla/5.0 (compatible; Embedded MySql; +https://github.com/lucatume/wp-browser'
-        );
+        // dev.mysql.com's CDN now 403s non-tool user agents; mirror the curl CLI's UA, which is allowed.
+        $curlVersion = curl_version();
+        curl_setopt($curlHandle, CURLOPT_USERAGENT, 'curl/' . ($curlVersion['version'] ?? '8.7.1'));
 
         if (!$verifyHost) {
             /** @noinspection CurlSslServerSpoofingInspection */

--- a/src/WordPress/Installation.php
+++ b/src/WordPress/Installation.php
@@ -70,6 +70,38 @@ class Installation
     }
 
     /**
+     * Scaffolds, configures with SQLite and installs WordPress: the installation produced by the
+     * default configuration. The returned installation exposes the database via getDb().
+     *
+     * Pass a concrete $version (e.g. "6.8.1") to reproduce a specific WordPress version; "latest"
+     * downloads the most recent release.
+     *
+     * @throws Throwable
+     */
+    public static function scaffoldWithSqlite(
+        string $wpRootDir,
+        string $dataDir,
+        string $url,
+        string $title,
+        string $version = 'latest'
+    ): self {
+        if (!is_dir($dataDir) && !(mkdir($dataDir, 0777, true) && is_dir($dataDir))) {
+            throw new InstallationException(
+                "Could not create the database directory $dataDir.",
+                InstallationException::WRITE_ERROR
+            );
+        }
+
+        $db = new SQLiteDatabase($dataDir, 'db.sqlite');
+        self::scaffold($wpRootDir, $version);
+        $installation = new self($wpRootDir);
+        $installation->configure($db);
+        $installation->install($url, 'admin', 'password', 'admin@example.com', $title);
+
+        return $installation;
+    }
+
+    /**
      * @return array<string>
      */
     public static function getCleanScaffoldedInstallations(): array

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_child_theme_correctly__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_child_theme_correctly__0.snapshot
@@ -207,9 +207,10 @@ class EndToEndTester extends \Codeception\Actor
 
 <<< /tests/Support/EndToEndTester.php <<<
 
->>> /tests/Support/Data/.gitkeep >>>
+>>> /tests/Support/Data/.gitignore >>>
+!dump.sql
 
-<<< /tests/Support/Data/.gitkeep <<<
+<<< /tests/Support/Data/.gitignore <<<
 
 >>> /tests/EndToEnd/_bootstrap.php >>>
 <?php

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_child_theme_correctly__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_child_theme_correctly__0.snapshot
@@ -272,8 +272,8 @@ TEST_TABLE_PREFIX=test_
 WORDPRESS_TABLE_PREFIX=wp_
 
 # The URL and domain of the WordPress site used in end-to-end tests.
-WORDPRESS_URL=http://localhost:8970
-WORDPRESS_DOMAIN=localhost:8970
+WORDPRESS_URL=http://localhost:39295
+WORDPRESS_DOMAIN=localhost:39295
 WORDPRESS_ADMIN_PATH=/wp-admin
 
 # The username and password of the administrator user of the WordPress site used in end-to-end tests.
@@ -282,10 +282,13 @@ WORDPRESS_ADMIN_PASSWORD=password
 
 # The host and port of the ChromeDriver server that will be used in end-to-end tests.
 CHROMEDRIVER_HOST=localhost
-CHROMEDRIVER_PORT=43956
+CHROMEDRIVER_PORT=34145
 
 # The port on which the PHP built-in server will serve the WordPress installation.
-BUILTIN_SERVER_PORT=8970
+BUILTIN_SERVER_PORT=39295
+# The WordPress version installed by `init`, reused by the `dev:rebuild` command.
+WORDPRESS_VERSION=7.0
+
 
 <<< /tests/.env <<<
 
@@ -341,6 +344,7 @@ extensions:
         - lucatume\WPBrowser\Command\DevStop
         - lucatume\WPBrowser\Command\DevInfo
         - lucatume\WPBrowser\Command\DevRestart
+        - lucatume\WPBrowser\Command\DevRebuild
         - lucatume\WPBrowser\Command\ChromedriverUpdate
 
 <<< /codeception.yml <<<

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_non_plugin_php_file__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_non_plugin_php_file__0.snapshot
@@ -267,8 +267,8 @@ TEST_TABLE_PREFIX=test_
 WORDPRESS_TABLE_PREFIX=wp_
 
 # The URL and domain of the WordPress site used in end-to-end tests.
-WORDPRESS_URL=http://localhost:27090
-WORDPRESS_DOMAIN=localhost:27090
+WORDPRESS_URL=http://localhost:31090
+WORDPRESS_DOMAIN=localhost:31090
 WORDPRESS_ADMIN_PATH=/wp-admin
 
 # The username and password of the administrator user of the WordPress site used in end-to-end tests.
@@ -277,10 +277,13 @@ WORDPRESS_ADMIN_PASSWORD=password
 
 # The host and port of the ChromeDriver server that will be used in end-to-end tests.
 CHROMEDRIVER_HOST=localhost
-CHROMEDRIVER_PORT=55678
+CHROMEDRIVER_PORT=16932
 
 # The port on which the PHP built-in server will serve the WordPress installation.
-BUILTIN_SERVER_PORT=27090
+BUILTIN_SERVER_PORT=31090
+# The WordPress version installed by `init`, reused by the `dev:rebuild` command.
+WORDPRESS_VERSION=7.0
+
 
 <<< /tests/.env <<<
 
@@ -336,6 +339,7 @@ extensions:
         - lucatume\WPBrowser\Command\DevStop
         - lucatume\WPBrowser\Command\DevInfo
         - lucatume\WPBrowser\Command\DevRestart
+        - lucatume\WPBrowser\Command\DevRebuild
         - lucatume\WPBrowser\Command\ChromedriverUpdate
 
 <<< /codeception.yml <<<

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_non_plugin_php_file__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_non_plugin_php_file__0.snapshot
@@ -194,9 +194,10 @@ class EndToEndTester extends \Codeception\Actor
 
 <<< /tests/Support/EndToEndTester.php <<<
 
->>> /tests/Support/Data/.gitkeep >>>
+>>> /tests/Support/Data/.gitignore >>>
+!dump.sql
 
-<<< /tests/Support/Data/.gitkeep <<<
+<<< /tests/Support/Data/.gitignore <<<
 
 >>> /tests/EndToEnd/_bootstrap.php >>>
 <?php

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_plugin_php_file__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_plugin_php_file__0.snapshot
@@ -272,8 +272,8 @@ TEST_TABLE_PREFIX=test_
 WORDPRESS_TABLE_PREFIX=wp_
 
 # The URL and domain of the WordPress site used in end-to-end tests.
-WORDPRESS_URL=http://localhost:45130
-WORDPRESS_DOMAIN=localhost:45130
+WORDPRESS_URL=http://localhost:17209
+WORDPRESS_DOMAIN=localhost:17209
 WORDPRESS_ADMIN_PATH=/wp-admin
 
 # The username and password of the administrator user of the WordPress site used in end-to-end tests.
@@ -282,10 +282,13 @@ WORDPRESS_ADMIN_PASSWORD=password
 
 # The host and port of the ChromeDriver server that will be used in end-to-end tests.
 CHROMEDRIVER_HOST=localhost
-CHROMEDRIVER_PORT=53682
+CHROMEDRIVER_PORT=9945
 
 # The port on which the PHP built-in server will serve the WordPress installation.
-BUILTIN_SERVER_PORT=45130
+BUILTIN_SERVER_PORT=17209
+# The WordPress version installed by `init`, reused by the `dev:rebuild` command.
+WORDPRESS_VERSION=7.0
+
 
 <<< /tests/.env <<<
 
@@ -341,6 +344,7 @@ extensions:
         - lucatume\WPBrowser\Command\DevStop
         - lucatume\WPBrowser\Command\DevInfo
         - lucatume\WPBrowser\Command\DevRestart
+        - lucatume\WPBrowser\Command\DevRebuild
         - lucatume\WPBrowser\Command\ChromedriverUpdate
 
 <<< /codeception.yml <<<

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_plugin_php_file__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_plugin_with_plugin_php_file__0.snapshot
@@ -199,9 +199,10 @@ class EndToEndTester extends \Codeception\Actor
 
 <<< /tests/Support/EndToEndTester.php <<<
 
->>> /tests/Support/Data/.gitkeep >>>
+>>> /tests/Support/Data/.gitignore >>>
+!dump.sql
 
-<<< /tests/Support/Data/.gitkeep <<<
+<<< /tests/Support/Data/.gitignore <<<
 
 >>> /tests/EndToEnd/_bootstrap.php >>>
 <?php

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_theme_correctly__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_theme_correctly__0.snapshot
@@ -207,9 +207,10 @@ class EndToEndTester extends \Codeception\Actor
 
 <<< /tests/Support/EndToEndTester.php <<<
 
->>> /tests/Support/Data/.gitkeep >>>
+>>> /tests/Support/Data/.gitignore >>>
+!dump.sql
 
-<<< /tests/Support/Data/.gitkeep <<<
+<<< /tests/Support/Data/.gitignore <<<
 
 >>> /tests/EndToEnd/_bootstrap.php >>>
 <?php

--- a/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_theme_correctly__0.snapshot
+++ b/tests/unit/Codeception/Template/__snapshots__/WpbrowserTest__should_scaffold_for_theme_correctly__0.snapshot
@@ -272,8 +272,8 @@ TEST_TABLE_PREFIX=test_
 WORDPRESS_TABLE_PREFIX=wp_
 
 # The URL and domain of the WordPress site used in end-to-end tests.
-WORDPRESS_URL=http://localhost:32075
-WORDPRESS_DOMAIN=localhost:32075
+WORDPRESS_URL=http://localhost:14673
+WORDPRESS_DOMAIN=localhost:14673
 WORDPRESS_ADMIN_PATH=/wp-admin
 
 # The username and password of the administrator user of the WordPress site used in end-to-end tests.
@@ -282,10 +282,13 @@ WORDPRESS_ADMIN_PASSWORD=password
 
 # The host and port of the ChromeDriver server that will be used in end-to-end tests.
 CHROMEDRIVER_HOST=localhost
-CHROMEDRIVER_PORT=26026
+CHROMEDRIVER_PORT=20421
 
 # The port on which the PHP built-in server will serve the WordPress installation.
-BUILTIN_SERVER_PORT=32075
+BUILTIN_SERVER_PORT=14673
+# The WordPress version installed by `init`, reused by the `dev:rebuild` command.
+WORDPRESS_VERSION=7.0
+
 
 <<< /tests/.env <<<
 
@@ -341,6 +344,7 @@ extensions:
         - lucatume\WPBrowser\Command\DevStop
         - lucatume\WPBrowser\Command\DevInfo
         - lucatume\WPBrowser\Command\DevRestart
+        - lucatume\WPBrowser\Command\DevRebuild
         - lucatume\WPBrowser\Command\ChromedriverUpdate
 
 <<< /codeception.yml <<<

--- a/tests/unit/lucatume/WPBrowser/Command/DevRebuildTest.php
+++ b/tests/unit/lucatume/WPBrowser/Command/DevRebuildTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace lucatume\WPBrowser\Command;
+
+use lucatume\WPBrowser\Exceptions\RuntimeException;
+
+/**
+ * @group fast
+ */
+class DevRebuildTest extends \Codeception\Test\Unit
+{
+    /**
+     * @test
+     */
+    public function resolves_relative_docroot_and_sqlite_data_dir(): void
+    {
+        [$wpRootDir, $dataDir, $url] = DevRebuild::resolveTarget([
+            'docroot' => 'tests/_wordpress',
+            'port' => 9876,
+            'env' => ['DATABASE_TYPE' => 'sqlite', 'DB_ENGINE' => 'sqlite'],
+        ], '/project');
+
+        $this->assertEquals('/project/tests/_wordpress', $wpRootDir);
+        $this->assertEquals('/project/tests/_wordpress/data', $dataDir);
+        $this->assertEquals('http://localhost:9876', $url);
+    }
+
+    /**
+     * @test
+     */
+    public function keeps_absolute_docroot_as_is(): void
+    {
+        [$wpRootDir, $dataDir, $url] = DevRebuild::resolveTarget([
+            'docroot' => '/abs/wp',
+            'env' => ['DB_ENGINE' => 'sqlite'],
+        ], '/project');
+
+        $this->assertEquals('/abs/wp', $wpRootDir);
+        $this->assertEquals('/abs/wp/data', $dataDir);
+        $this->assertEquals('http://localhost', $url);
+    }
+
+    /**
+     * @test
+     */
+    public function rejects_non_sqlite_configuration(): void
+    {
+        $this->expectException(RuntimeException::class);
+        DevRebuild::resolveTarget([
+            'docroot' => 'tests/_wordpress',
+            'env' => ['DATABASE_TYPE' => 'mysql'],
+        ], '/project');
+    }
+
+    /**
+     * @test
+     */
+    public function rejects_missing_built_in_server_configuration(): void
+    {
+        $this->expectException(RuntimeException::class);
+        DevRebuild::resolveTarget([], '/project');
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_version_with_option_taking_precedence(): void
+    {
+        $this->assertEquals('6.8.1', DevRebuild::resolveVersion('6.8.1', '6.7'));
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_version_from_environment_when_no_option(): void
+    {
+        $this->assertEquals('6.7', DevRebuild::resolveVersion(null, '6.7'));
+        $this->assertEquals('6.7', DevRebuild::resolveVersion('', '6.7'));
+    }
+
+    /**
+     * @test
+     */
+    public function resolves_version_to_latest_when_nothing_set(): void
+    {
+        $this->assertEquals('latest', DevRebuild::resolveVersion(null, false));
+        $this->assertEquals('latest', DevRebuild::resolveVersion(null, ''));
+        $this->assertEquals('latest', DevRebuild::resolveVersion('', null));
+    }
+}

--- a/tests/unit/lucatume/WPBrowser/WordPress/InstallationTest.php
+++ b/tests/unit/lucatume/WPBrowser/WordPress/InstallationTest.php
@@ -676,4 +676,34 @@ PHP;
 
         Installation::findInDir($dir);
     }
+
+    /**
+     * It should scaffold, configure with SQLite and install WordPress with the drop-in in place.
+     *
+     * This is the provisioning path used by the `dev:rebuild` command and `init`.
+     *
+     * @test
+     * @group slow
+     */
+    public function should_scaffold_configure_and_install_wordpress_on_sqlite(): void
+    {
+        $wpRoot = FS::tmpDir('installation_');
+        $dataDir = $wpRoot . '/data';
+        $version = Env::get('WORDPRESS_VERSION') ?: 'latest';
+
+        $installation = Installation::scaffoldWithSqlite(
+            $wpRoot,
+            $dataDir,
+            'http://localhost:2389',
+            'Test',
+            $version
+        );
+
+        $this->assertInstanceOf(Single::class, $installation->getState());
+        $this->assertInstanceOf(SQLiteDatabase::class, $installation->getDb());
+        // The SQLite drop-in and its mu-plugin must be on disk or the served site cannot use SQLite.
+        $this->assertFileExists($wpRoot . '/wp-content/db.php');
+        $this->assertDirectoryExists($wpRoot . '/wp-content/mu-plugins/sqlite-database-integration');
+        $this->assertFileExists($dataDir . '/db.sqlite');
+    }
 }


### PR DESCRIPTION
Addresses #807

Adds a `dev:rebuild` command to setup using the recommended configuration (SQLite + PHP built-in web-server) locally and have it re-created in CI.
Minimal workflow example (provided locally all is set up):

```yaml
- uses: actions/checkout@v4
- uses: shivammathur/setup-php@v2
  with:
    php-version: '8.3'
    extensions: sqlite3, pdo_sqlite
- run: composer install --no-interaction --prefer-dist
- run: vendor/bin/codecept dev:rebuild
- run: vendor/bin/codecept chromedriver:update --binary "$(which google-chrome)"
- run: vendor/bin/codecept run
```
Note the `chromedriver:update` command to leverage the Chrome version already installed in GitHub Actions.

This also adds a curated `.gitignore` section to the recommended setup (another gap highlighted in the issue).

The WordPress version can be pinned by setting the `WORDPRESS_VERSION` env var (e.g. in the `tests/.env` file) or by using the `--wp-version` option of the `dev:rebuild` command.
