### PR TITLE
Unhook core icon registration after init, as WordPress 7.1's suite does

### DIFF
--- a/includes/core-phpunit/includes/functions.php
+++ b/includes/core-phpunit/includes/functions.php
@@ -376,6 +376,18 @@ function _unhook_font_registration() {
 tests_add_filter( 'init', '_unhook_font_registration', 1000 );
 
 /**
+ * After the init action has been run once, trying to re-register icon collections and icons
+ * can cause errors. To avoid this, unhook the icon registration functions.
+ *
+ * @since 7.1.0
+ */
+function _unhook_icon_registration() {
+	remove_action( 'init', '_wp_register_default_icon_collections', 0 );
+	remove_action( 'init', '_wp_register_default_icons' );
+}
+tests_add_filter( 'init', '_unhook_icon_registration', 1000 );
+
+/**
  * After the init action has been run once, trying to re-register connector settings can cause
  * duplicate registrations. To avoid this, unhook the connector registration functions.
  *


### PR DESCRIPTION
## Problem

WordPress 7.1 registers its default icon collections and icons on `init`:

```php
// src/wp-includes/default-filters.php
add_action( 'init', '_wp_register_default_icon_collections', 0 );
add_action( 'init', '_wp_register_default_icons' );
```

Registering either a second time calls `_doing_it_wrong()`. Any test that fires `init` again re-runs both callbacks, the notices land in `caught_doing_it_wrong`, and `WP_UnitTestCase_Base::assert_post_conditions()` fails the test:

```
Unexpected incorrect usage notice for WP_Icon_Collections_Registry::register.
Icon collection is already registered. (This message was added in version 7.1.0.)
Unexpected incorrect usage notice for WP_Icons_Registry::register.
Icon is already registered. (This message was added in version 7.1.0.)
Failed asserting that an array is empty.
```

Nothing in the plugin under test is at fault, and the test suite goes red the moment 7.1 becomes the WordPress version under test — no commit involved, which makes it puzzling to track down.

## Fix

WordPress added `_unhook_icon_registration()` to its own test bootstrap in 7.1 for precisely this, alongside the font and connector guards `includes/core-phpunit/includes/functions.php` already carries:

https://github.com/WordPress/wordpress-develop/blob/trunk/tests/phpunit/includes/functions.php

This ports it verbatim, placed between `_unhook_font_registration()` and `_unhook_connector_registration()` to match the ordering in core's file, so a future sync of these includes produces no conflict.

```php
function _unhook_icon_registration() {
	remove_action( 'init', '_wp_register_default_icon_collections', 0 );
	remove_action( 'init', '_wp_register_default_icons' );
}
tests_add_filter( 'init', '_unhook_icon_registration', 1000 );
```

Inert on WordPress before 7.1: `remove_action()` on a callback that was never added is a no-op.

## How I hit it

Our plugin's suite went red across the whole matrix when 7.1 shipped. I worked around it locally by adding the same guard to our test bootstrap plugin, then found core had already solved it and that this file has the font and connector guards but not the icon one. Better fixed here so nobody else has to work it out.